### PR TITLE
Add basic validation for contact forms

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -361,6 +361,11 @@
     const topic = document.getElementById('storyCategory').value;
     const message = document.getElementById('storyMessage').value.trim();
 
+    if (!contact && !message) {
+      alert('Please provide at least your email, phone, or a message.');
+      return false;
+    }
+
     const to = 'info@arafatforcongress.org';
     const subject = encodeURIComponent(`Story: ${topic}${name ? ' - ' + name : ''}`);
     const bodyLines = [];

--- a/test1.html
+++ b/test1.html
@@ -158,15 +158,25 @@
   async function submitContact(e){
     e.preventDefault();
 
+    const name = document.getElementById('storyName').value.trim();
+    const email = document.getElementById('storyContact').value.trim();
+    const phone = '';
+    const message = document.getElementById('storyMessage').value.trim();
+
+    if (!email && !phone && !message) {
+      alert('Please provide at least your email, phone, or a message.');
+      return false;
+    }
+
     const payload = {
       source: 'website',
       type: 'contact',
-      name: document.getElementById('storyName').value.trim(),
-      email: document.getElementById('storyContact').value.trim(),
-      phone: '',
+      name,
+      email,
+      phone,
       zip: '',
       topic: document.getElementById('storyCategory').value,
-      message: document.getElementById('storyMessage').value.trim(),
+      message,
       utm_source: getUTM('utm_source'),
       utm_medium: getUTM('utm_medium'),
       utm_campaign: getUTM('utm_campaign'),


### PR DESCRIPTION
## Summary
- prevent empty contact submissions by requiring email, phone, or message before sending

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade609a9b4832380fc2403ed4552f5