### PR TITLE
Fix signature form and backend counts

### DIFF
--- a/Bills/Bills2.html
+++ b/Bills/Bills2.html
@@ -249,7 +249,7 @@
     if (candEl) candEl.textContent = '';
     if (voterEl) voterEl.textContent = '';
     try {
-      const res = await fetch(API);
+      const res = await fetch(API, { cache: "no-cache" });
       if (!res.ok) throw new Error('network');
       const data = await res.json();
       if (candEl && data.candidateCount != null) candEl.textContent = data.candidateCount;
@@ -305,8 +305,8 @@
 
       const base = formToJSON(form);
       const email = (base[fieldMap.email.id] || "").toLowerCase();
-
-        ? ((base[fieldMap.confirm.id] === "true") ? "true" : "false")
+      const candidateConfirmed = fieldMap.confirm
+        ? (base[fieldMap.confirm.id] === "true" ? "true" : "false")
         : "false";
 
       if (type === "candidate" && candidateConfirmed !== "true") {
@@ -337,6 +337,7 @@
         if (!ok) { setMsg(msgEl, "Submit error. Please try again.", false); return; }
         setMsg(msgEl, "Thank you! Your signature was recorded.", true);
         bumpCount(countElId);
+        loadCounts();
         form.reset();
         clearValidation(form);
         kickAutofill(form);

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,32 +1,119 @@
+const SPREADSHEET_ID  = '1QsCLdoqe4h_vtifUfbJFKOWHk_zAcNEnc6aXeQ8mLRY';
+const SIGNATURES_SHEET = 'signatures';
+const STORE_RAW_EMAIL  = true;
+
+const CACHE_KEY  = 'counts_v1';
+const CACHE_SECS = 300; // 5 minutes
+
+function sheet(name) {
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  let sh = ss.getSheetByName(name);
+  if (!sh) sh = ss.insertSheet(name);
+  return sh;
+}
+
+function out(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function ensureHeader(name) {
+  const sh = sheet(name);
+  const headers = [
+    'timestamp', 'type', 'email', 'email_hash', 'ip', 'city', 'state',
+    'user_agent', 'first_name', 'last_name'
+  ];
+  const first = sh.getRange(1, 1, 1, headers.length).getValues()[0];
+  const empty = first.every(v => String(v).trim() === '');
+  if (empty) sh.getRange(1, 1, 1, headers.length).setValues([headers]);
+}
+
+function parseBody(e) {
+  let body = {};
+  if (e && e.postData) {
+    const ct = String(e.postData.type || '').toLowerCase();
+    if (ct.includes('application/json')) {
+      body = JSON.parse(e.postData.contents || '{}');
+    } else if (ct.includes('application/x-www-form-urlencoded')) {
+      body = e.parameter || {};
+    }
+  }
+  return body;
+}
+
 function doGet(e) {
   const cache = CacheService.getScriptCache();
-  const cached = cache.get('signature_counts');
+  const cached = cache.get(CACHE_KEY);
   if (cached) {
     return ContentService.createTextOutput(cached)
       .setMimeType(ContentService.MimeType.JSON);
   }
 
-  const ss = SpreadsheetApp.getActive().getSheetByName('signatures');
-  if (!ss) {
-    const empty = JSON.stringify({ candidateCount: 0, voterCount: 0 });
-    return ContentService.createTextOutput(empty)
-      .setMimeType(ContentService.MimeType.JSON);
-  }
-
-  const values = ss.getDataRange().getValues();
-  const headers = values[0].map(String).map(h => h.toLowerCase());
-  const typeIdx = headers.indexOf('type');
+  const sh = sheet(SIGNATURES_SHEET);
+  const values = sh.getDataRange().getValues();
   let candidateCount = 0;
   let voterCount = 0;
-  for (let i = 1; i < values.length; i++) {
-    const row = values[i];
-    const type = String(typeIdx > -1 ? row[typeIdx] : row[0]).toLowerCase();
+  for (let r = 1; r < values.length; r++) {
+    const type = String(values[r][1] || '').toLowerCase();
     if (type === 'candidate') candidateCount++;
     else if (type === 'voter') voterCount++;
   }
-
   const payload = JSON.stringify({ candidateCount, voterCount });
-  cache.put('signature_counts', payload, 1800); // cache for 30 minutes
+  cache.put(CACHE_KEY, payload, CACHE_SECS);
   return ContentService.createTextOutput(payload)
     .setMimeType(ContentService.MimeType.JSON);
 }
+
+function doPost(e) {
+  try {
+    const body = parseBody(e);
+    const type = String(body.type || '').toLowerCase().trim();
+    const email = String(body.email || '').toLowerCase().trim();
+    const firstName = String(body.firstName || '').trim();
+    const lastName = String(body.lastName || '').trim();
+    const city = String(body.city || '').trim();
+    const state = String(body.state || '').trim();
+    const userAgent = String(body.userAgent || '').trim();
+
+    if (!['candidate', 'voter'].includes(type)) throw new Error('Invalid "type".');
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error('Invalid "email".');
+    if (!firstName || !lastName) throw new Error('First and last name are required.');
+
+    const emailHash = Utilities.base64Encode(
+      Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, email)
+    );
+
+    const ip = e.parameter['x-forwarded-for'] || e.parameter['cf-connecting-ip'] || '';
+
+    ensureHeader(SIGNATURES_SHEET);
+    const sh = sheet(SIGNATURES_SHEET);
+    const values = sh.getDataRange().getValues();
+    for (let r = 1; r < values.length; r++) {
+      const rowType = (values[r][1] || '').toString().toLowerCase();
+      const rowHash = (values[r][3] || '').toString();
+      if (rowType === type && rowHash === emailHash) {
+        return out({ ok: true, duplicate: true });
+      }
+    }
+
+    sh.appendRow([
+      new Date(),
+      type,
+      STORE_RAW_EMAIL ? email : '',
+      emailHash,
+      ip,
+      city,
+      state,
+      userAgent,
+      firstName,
+      lastName
+    ]);
+
+    CacheService.getScriptCache().remove(CACHE_KEY);
+
+    return out({ ok: true, duplicate: false });
+  } catch (err) {
+    return out({ ok: false, error: String(err) });
+  }
+}
+


### PR DESCRIPTION
## Summary
- fix client-side candidate confirmation handling and refresh counts
- add Apps Script backend to accept signatures and return counts with cache busting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adecd2efdc8323beed43042a8b0dfc