### PR TITLE
Fix signature form and backend counts

### DIFF
--- a/Bills/Bills2.html
+++ b/Bills/Bills2.html
@@ -239,8 +239,10 @@
       redirect: "follow",
       mode: "cors"
     });
-    const ok = res.status >= 200 && res.status < 300;
-    return { ok, status: res.status };
+    let data = null;
+    try { data = await res.json(); } catch (err) {}
+    const ok = res.ok && data && data.ok;
+    return { ok, status: res.status, data };
   }
 
   async function loadCounts() {
@@ -249,7 +251,7 @@
     if (candEl) candEl.textContent = '';
     if (voterEl) voterEl.textContent = '';
     try {
-      const res = await fetch(API);
+      const res = await fetch(API, { cache: "no-cache" });
       if (!res.ok) throw new Error('network');
       const data = await res.json();
       if (candEl && data.candidateCount != null) candEl.textContent = data.candidateCount;
@@ -258,12 +260,10 @@
       console.error('Failed to load counts', err);
     }
   }
-  function bumpCount(elId) {
+  function setCount(elId, value) {
     const el = byId(elId);
     if (!el) return;
-    const cur = parseInt((el.textContent || "").replace(/[^0-9]/g,""),10);
-    const next = Number.isFinite(cur) ? cur + 1 : 1;
-    el.textContent = String(next);
+    el.textContent = String(value);
     el.classList.add("flash");
     setTimeout(()=>el.classList.remove("flash"), 600);
   }
@@ -273,7 +273,7 @@
     if (autocomplete && !el.getAttribute("autocomplete")) el.setAttribute("autocomplete", autocomplete);
   }
 
-  function wireSignatureForm({ formId, type, countElId, msgElId, fieldMap }) {
+  function wireSignatureForm({ formId, type, msgElId, fieldMap }) {
     const form = byId(formId);
     if (!form) return;
     const msgEl = byId(msgElId);
@@ -305,8 +305,8 @@
 
       const base = formToJSON(form);
       const email = (base[fieldMap.email.id] || "").toLowerCase();
-
-        ? ((base[fieldMap.confirm.id] === "true") ? "true" : "false")
+      const candidateConfirmed = fieldMap.confirm
+        ? (base[fieldMap.confirm.id] === "true" ? "true" : "false")
         : "false";
 
       if (type === "candidate" && candidateConfirmed !== "true") {
@@ -333,10 +333,15 @@
       setMsg(msgEl, "Submitting…", true);
 
       try {
-        const { ok } = await postForm(API, payload);
+        const { ok, data } = await postForm(API, payload);
         if (!ok) { setMsg(msgEl, "Submit error. Please try again.", false); return; }
-        setMsg(msgEl, "Thank you! Your signature was recorded.", true);
-        bumpCount(countElId);
+        if (data.duplicate) {
+          setMsg(msgEl, "You already signed.", true);
+        } else {
+          setMsg(msgEl, "Thank you! Your signature was recorded.", true);
+        }
+        if (data.candidateCount != null) setCount('candidateCount', data.candidateCount);
+        if (data.voterCount != null) setCount('voterCount', data.voterCount);
         form.reset();
         clearValidation(form);
         kickAutofill(form);
@@ -357,7 +362,6 @@
     wireSignatureForm({
       formId: "candidateForm",
       type: "candidate",
-      countElId: "candidateCount",
       msgElId: "candidateMsg",
       fieldMap: {
         first:  { id: "candidateFirst", name: "candidateFirst", autocomplete: "given-name" },
@@ -372,7 +376,6 @@
     wireSignatureForm({
       formId: "voterForm",
       type: "voter",
-      countElId: "voterCount",
       msgElId: "voterMsg",
       fieldMap: {
         first:  { id: "voterFirst", name: "voterFirst", autocomplete: "given-name" },

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,32 +1,128 @@
+const SPREADSHEET_ID  = '1QsCLdoqe4h_vtifUfbJFKOWHk_zAcNEnc6aXeQ8mLRY';
+const SIGNATURES_SHEET = 'signatures';
+const STORE_RAW_EMAIL  = true;
+
+const CACHE_KEY  = 'counts_v1';
+const CACHE_SECS = 300; // 5 minutes
+
+function sheet(name) {
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  let sh = ss.getSheetByName(name);
+  if (!sh) sh = ss.insertSheet(name);
+  return sh;
+}
+
+function out(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function ensureHeader(name) {
+  const sh = sheet(name);
+  const headers = [
+    'timestamp', 'type', 'email', 'email_hash', 'ip', 'city', 'state',
+    'user_agent', 'first_name', 'last_name', 'candidate_confirmed'
+  ];
+  const first = sh.getRange(1, 1, 1, headers.length).getValues()[0];
+  const empty = first.every(v => String(v).trim() === '');
+  if (empty) sh.getRange(1, 1, 1, headers.length).setValues([headers]);
+}
+
+function parseBody(e) {
+  let body = {};
+  if (e && e.postData) {
+    const ct = String(e.postData.type || '').toLowerCase();
+    if (ct.includes('application/json')) {
+      body = JSON.parse(e.postData.contents || '{}');
+    } else if (ct.includes('application/x-www-form-urlencoded')) {
+      body = e.parameter || {};
+    }
+  }
+  return body;
+}
+
 function doGet(e) {
   const cache = CacheService.getScriptCache();
-  const cached = cache.get('signature_counts');
+  const cached = cache.get(CACHE_KEY);
   if (cached) {
     return ContentService.createTextOutput(cached)
       .setMimeType(ContentService.MimeType.JSON);
   }
 
-  const ss = SpreadsheetApp.getActive().getSheetByName('signatures');
-  if (!ss) {
-    const empty = JSON.stringify({ candidateCount: 0, voterCount: 0 });
-    return ContentService.createTextOutput(empty)
-      .setMimeType(ContentService.MimeType.JSON);
-  }
-
-  const values = ss.getDataRange().getValues();
-  const headers = values[0].map(String).map(h => h.toLowerCase());
-  const typeIdx = headers.indexOf('type');
+  const sh = sheet(SIGNATURES_SHEET);
+  const values = sh.getDataRange().getValues();
   let candidateCount = 0;
   let voterCount = 0;
-  for (let i = 1; i < values.length; i++) {
-    const row = values[i];
-    const type = String(typeIdx > -1 ? row[typeIdx] : row[0]).toLowerCase();
+  for (let r = 1; r < values.length; r++) {
+    const type = String(values[r][1] || '').toLowerCase();
     if (type === 'candidate') candidateCount++;
     else if (type === 'voter') voterCount++;
   }
-
   const payload = JSON.stringify({ candidateCount, voterCount });
-  cache.put('signature_counts', payload, 1800); // cache for 30 minutes
+  cache.put(CACHE_KEY, payload, CACHE_SECS);
   return ContentService.createTextOutput(payload)
     .setMimeType(ContentService.MimeType.JSON);
 }
+
+function doPost(e) {
+  try {
+    const body = parseBody(e);
+    const type = String(body.type || '').toLowerCase().trim();
+    const email = String(body.email || '').toLowerCase().trim();
+    const firstName = String(body.firstName || '').trim();
+    const lastName = String(body.lastName || '').trim();
+    const city = String(body.city || '').trim();
+    const state = String(body.state || '').trim();
+    const userAgent = String(body.userAgent || '').trim();
+    const candidateConfirmed = String(body.candidateConfirmed || '').toLowerCase() === 'true';
+
+    if (!['candidate', 'voter'].includes(type)) throw new Error('Invalid "type".');
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error('Invalid "email".');
+    if (!firstName || !lastName) throw new Error('First and last name are required.');
+
+    const emailHash = Utilities.base64Encode(
+      Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, email)
+    );
+
+    const ip = e.parameter['x-forwarded-for'] || e.parameter['cf-connecting-ip'] || '';
+
+    ensureHeader(SIGNATURES_SHEET);
+    const sh = sheet(SIGNATURES_SHEET);
+    const values = sh.getDataRange().getValues();
+    let candidateCount = 0;
+    let voterCount = 0;
+    for (let r = 1; r < values.length; r++) {
+      const rowType = (values[r][1] || '').toString().toLowerCase();
+      const rowHash = (values[r][3] || '').toString();
+      if (rowType === 'candidate') candidateCount++;
+      else if (rowType === 'voter') voterCount++;
+      if (rowType === type && rowHash === emailHash) {
+        return out({ ok: true, duplicate: true, candidateCount, voterCount });
+      }
+    }
+
+    sh.appendRow([
+      new Date(),
+      type,
+      STORE_RAW_EMAIL ? email : '',
+      emailHash,
+      ip,
+      city,
+      state,
+      userAgent,
+      firstName,
+      lastName,
+      candidateConfirmed ? 'true' : 'false'
+    ]);
+
+    if (type === 'candidate') candidateCount++;
+    else if (type === 'voter') voterCount++;
+
+    CacheService.getScriptCache().remove(CACHE_KEY);
+
+    return out({ ok: true, duplicate: false, candidateCount, voterCount });
+  } catch (err) {
+    return out({ ok: false, error: String(err) });
+  }
+}
+


### PR DESCRIPTION
## Summary
- track candidate confirmation and save to sheet with counts
- update HTML form to parse JSON response and refresh both signature counts immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adecd2efdc8323beed43042a8b0dfc