### PR TITLE
Fix signature form submission and count updates

### DIFF
--- a/Bills/Bills2.html
+++ b/Bills/Bills2.html
@@ -334,23 +334,24 @@
 
       try {
         const { ok, data } = await postForm(API, payload);
-        if (!ok) { setMsg(msgEl, "Submit error. Please try again.", false); return; 
-                  
-                codex/fix-form-submission-and-validation-issues
+        if (!ok) {
+          setMsg(msgEl, "Submit error. Please try again.", false);
+          return;
+        }
+
         if (data.duplicate) {
           setMsg(msgEl, "You already signed.", true);
         } else {
           setMsg(msgEl, "Thank you! Your signature was recorded.", true);
         }
+
         if (data.candidateCount != null) setCount('candidateCount', data.candidateCount);
         if (data.voterCount != null) setCount('voterCount', data.voterCount);
-        setMsg(msgEl, "Thank you! Your signature was recorded.", true);
-        bumpCount(countElId);
-        loadCounts();
-                 main
+
         form.reset();
         clearValidation(form);
         kickAutofill(form);
+        loadCounts();
       } catch (err) {
         console.error(err);
         setMsg(msgEl, "Sorry—could not submit. Please try again in a moment.", false);


### PR DESCRIPTION
## Summary
- fix Evergreen Pact form JS to correctly handle submission success and errors
- update counts and reset form after successful signature

## Testing
- `node -e "const fs=require('fs');const m=fs.readFileSync('Bills/Bills2.html','utf8').match(/<script>([\s\S]*)<\/script>/);try{new Function(m[1]);console.log('OK');}catch(e){console.error('Syntax error',e.message);process.exit(1);}"`


------
https://chatgpt.com/codex/tasks/task_e_68adf4808ff8832393a4a7a2c93ae7e0