### PR TITLE
Remove mailing address from footers

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -345,7 +345,6 @@
   <div class="container">
     <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
     <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">2007 197th St Ct E, Spanaway, WA 98387</p>
     <p class="small text-muted mb-0">Not authorized by any other candidate or candidate's committee.</p>
   </div>
 </footer>

--- a/contrast.html
+++ b/contrast.html
@@ -363,7 +363,6 @@
   <div class="container">
     <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
     <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">2007 197th St Ct E, Spanaway, WA 98387</p>
     <p class="small text-muted mb-3">Not authorized by any other candidate or candidate's committee.</p>
   </div>
 </footer>

--- a/digging-into-the-issues.html
+++ b/digging-into-the-issues.html
@@ -369,7 +369,6 @@
   <div class="container">
     <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
     <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">2007 197th St Ct E, Spanaway, WA 98387</p>
     <p class="small text-muted mb-3">Not authorized by any other candidate’s committee.</p>
   </div>
 </footer>

--- a/index.html
+++ b/index.html
@@ -233,7 +233,6 @@
   <div class="container">
     <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
     <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">2007 197th St Ct E, Spanaway, WA 98387</p>
     <p class="small text-muted mb-3">Not authorized by any other candidate or candidate's committee</p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Remove street address lines from site footers

## Testing
- `rg "2007 197th St Ct E" -n`
- ⚠️ `tidy --version` *(missing: command not found)*
- ⚠️ `pip install beautifulsoup4` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b381db15c483239b497154c7672c07