### PR TITLE
Revamp homepage layout and copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
   <base href="/">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Adam Neil Arafat for Congress - Washington's 10th District</title>
+  <title>Adam Neil Arafat for Congress – WA-10</title>
   <meta name="theme-color" content="#0d3b66" />
-  <meta name="description" content="A people-powered campaign for WA-10: Medicare for All, lower costs, more housing, and honest government without corporate PAC money." />
+  <meta name="description" content="20-year Army veteran. Infrastructure steward. Dad in WA-10 schools. People over PACs. Join the movement." />
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
@@ -18,10 +18,29 @@
     a { text-decoration: none; }
 
     /* Utilities */
-    .section-pad { padding: 3rem 0; }
-    .section-alt { background: #f8fafc; }
-    .section-title { font-weight: 800; color: #0b2540; }
+    .section-pad { padding:4rem 0; }
+    @media (max-width:767.98px){ .section-pad{ padding:2rem 0; } }
+    .section-alt { background:#f8fafc; }
+    .section-title { font-weight:800; color:#0b2540; }
     .lead { color:#1c2b3a; }
+
+    /* Hero */
+    .hero { position:relative; min-height:60vh; }
+    .hero img.bg{position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:-2;}
+    .hero::before { content:""; position:absolute; inset:0; background:rgba(0,0,0,.45); z-index:-1; }
+    .hero > .container { position:relative; }
+    .hero h1 { font-size:2.5rem; }
+    @media (min-width:768px){ .hero{min-height:70vh;} .hero h1{font-size:3rem;} }
+
+    /* Impact bar */
+    .impact-item h3{font-size:1.25rem;font-weight:700;}
+    .impact-item p{margin-bottom:0;}
+
+    /* Values icons hidden on mobile */
+    @media (max-width:767.98px){ .values-list i{display:none;} }
+
+    /* Timeline */
+    .timeline-step i{color:var(--primary);}
 
     /* Social bar */
     .social-top { background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%); color:#fff; }
@@ -76,30 +95,16 @@
     }
     .navbar .nav-link:hover::after, .navbar .nav-link:focus::after, .navbar .nav-link[aria-current="page"]::after { width:100%; }
 
-    /* Why it matters */
-    #why-it-matters ul { padding-left: 1.1rem; }
-    #why-it-matters li { margin-bottom: .25rem; }
-
     /* Meet Adam image sizing */
-    .about-photo { max-width: 70%; height: auto; }
-    @media (max-width: 767.98px) {
-      .about-photo { max-width: 95%; margin-bottom: 1rem; }
-    }
-
-    /* Cards under Meet Adam */
-    .info-card {
-      border:1px solid #e9eef3; background:#ffffff; border-radius:14px; padding:1.25rem;
-      box-shadow:0 6px 16px rgba(13,59,102,.06);
-      height:100%;
-      transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease;
-    }
-    .info-card:hover { transform: translateY(-2px); box-shadow:0 12px 28px rgba(13,59,102,.12); border-color:#d8e4ee; }
+    .about-photo { max-width:70%; height:auto; }
+    @media (max-width:767.98px){ .about-photo{ max-width:95%; margin-bottom:1rem; } }
 
     /* Buttons */
     .btn-primary { background: var(--primary); border-color: var(--primary); }
     .btn-primary:hover { background:#0b2f52; border-color:#0b2f52; }
     .btn-outline-primary { color: var(--primary); border-color: var(--primary); }
     .btn-outline-primary:hover { background: var(--primary); color:#fff; }
+    .btn:focus-visible { outline:2px solid #000; outline-offset:2px; }
 
     .btn-donate {
       background: var(--donate);
@@ -153,6 +158,7 @@
         <li class="nav-item"><a class="nav-link" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
+        <li class="nav-item ms-lg-3"><a class="btn btn-primary" href="/contact.html">Join the Movement</a></li>
       </ul>
     </div>
   </div>
@@ -160,74 +166,108 @@
 
 <main id="main">
 
-  <!-- WHY IT MATTERS -->
-  <section id="why-it-matters" class="section-pad">
+  <!-- HERO -->
+  <section class="hero d-flex align-items-center text-center text-white">
+    <img src="images/IMG_4344.jpeg" alt="Adam Arafat speaking with WA-10 residents in Spanaway park." class="bg" loading="lazy">
     <div class="container">
-      <h1 class="mb-3">Power People. Not PACs.</h1>
-      <ul class="mb-0">
-        <li><strong>Too much outside money</strong> the incumbent’s funding leans heavily outside WA-10. That’s influence, not independence.</li>
-        <li><strong>Too few hard wins</strong> lots of bills filed, few real victories on healthcare, housing, or costs.</li>
-        <li><strong>Neighbors first</strong> no corporate PAC money. Local voices set the agenda.</li>
+      <h1 class="fw-bold mb-3">Service. Accountability. WA-10 First.</h1>
+      <p class="lead mb-4">20 years in uniform. Infrastructure, schools, family—this district is who I serve.</p>
+      <div class="d-flex flex-column flex-md-row gap-3 justify-content-center">
+        <a class="btn btn-primary btn-lg" href="/contact.html" onclick="track('join_hero')" aria-label="Join the movement">Join the Movement</a>
+        <a class="btn btn-outline-light btn-lg" href="/digging-into-the-issues.html" onclick="track('plan_hero')" aria-label="Read the plan">Read the Plan</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- IMPACT BAR -->
+  <section class="impact-bar section-pad section-alt">
+    <div class="container">
+      <div class="row g-3 text-center">
+        <div class="col-md-4 impact-item">
+          <h3>20 Years of Service</h3>
+          <p>Army aviation &amp; airfield operations.</p>
+        </div>
+        <div class="col-md-4 impact-item">
+          <h3>Infrastructure Stewardship</h3>
+          <p>Keeps critical county systems running.</p>
+        </div>
+        <div class="col-md-4 impact-item">
+          <h3>Family in WA-10 Schools</h3>
+          <p>Raising kids in our public schools.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ABOUT -->
+  <section id="about" class="section-pad">
+    <div class="container">
+      <h2 class="section-title mb-4">About Adam</h2>
+      <div class="row align-items-center g-4">
+        <div class="col-md-5 text-center">
+          <img class="about-photo img-fluid" src="images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" alt="Adam Neil Arafat headshot" loading="lazy">
+        </div>
+        <div class="col-md-7">
+          <p>I served 20 years in the Army and now work to keep our local infrastructure running so families in WA-10 have reliable services every day. I’m a husband and dad, raising kids in our public schools.</p>
+          <p>I’m not a career politician. I won’t take PAC money. I’m running for Congress to deliver <a href="/digging-into-the-issues.html#universal-healthcare">healthcare we can afford</a>, housing we can access, and a government that works for working people.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- VALUES -->
+  <section id="values" class="section-pad section-alt">
+    <div class="container">
+      <h2 class="section-title mb-4">Values</h2>
+      <ul class="values-list list-unstyled mb-0">
+        <li class="mb-2"><i class="fa-solid fa-check text-success me-2"></i><strong>Service</strong> — Country, community, family.</li>
+        <li class="mb-2"><i class="fa-solid fa-check text-success me-2"></i><strong>Accountability</strong> — No PAC money. No corporate strings.</li>
+        <li><i class="fa-solid fa-check text-success me-2"></i><strong>Fairness</strong> — Policies that put working families first.</li>
       </ul>
     </div>
   </section>
 
-  <!-- MEET ADAM -->
-  <section id="meet-adam" class="section-pad section-alt">
-    <div class="container">
-      <h2 class="section-title mb-4">Meet Adam</h2>
-      <div class="row align-items-center g-4">
-        <div class="col-md-5 text-center">
-          <img
-            class="about-photo img-fluid"
-            src="images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg"
-            alt="Adam Neil Arafat headshot"
-            loading="lazy"
-          />
+  <!-- EVERGREEN PACT -->
+  <section id="pact" class="section-pad">
+    <div class="container text-center">
+      <h2 class="section-title mb-3">The Evergreen Pact</h2>
+      <p class="lead mb-4">A focused sequence of bill blueprints to notch early wins, build leverage, then tackle the hardest fights.</p>
+      <a href="/digging-into-the-issues.html" class="d-flex flex-column flex-md-row gap-4 justify-content-center align-items-start text-decoration-none text-body mb-4" onclick="track('pact_timeline_click')" aria-label="Explore the Evergreen Pact">
+        <div class="timeline-step text-center">
+          <i class="fa-solid fa-arrow-down fa-2x mb-2" aria-hidden="true"></i>
+          <div>Lower Costs</div>
         </div>
-        <div class="col-md-7">
-          <p>I’m a 20-year Army veteran who built aviation maintenance programs and led airfield operations around the globe. Service taught me discipline, accountability, and to put people first.</p>
-          <p>Today I work in county public service delivering infrastructure that hundreds of thousands rely on. My family and I live in Spanaway—this is our home.</p>
-          <p class="mb-2"><strong>My Values</strong></p>
-          <ul class="mb-0">
-            <li><strong>Service</strong> — Country, community, family.</li>
-            <li><strong>Accountability</strong> — No PAC money. No corporate strings.</li>
-            <li><strong>Fairness</strong> — Policies that put working families first.</li>
-          </ul>
+        <div class="timeline-step text-center">
+          <i class="fa-solid fa-stethoscope fa-2x mb-2" aria-hidden="true"></i>
+          <div>Universal Healthcare</div>
         </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Evergreen Pact + Contrast cards -->
-  <section class="section-pad">
-    <div class="container">
-      <div class="row g-4">
-        <div class="col-md-6">
-          <div class="info-card h-100">
-            <h3 class="h5 mb-2">The Evergreen Pact</h3>
-            <p class="mb-3">A focused set of bill blueprints in a deliberate order. Win early, build leverage, and take on the hard fights with momentum.</p>
-            <a class="btn btn-primary" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1"></i> Explore the plan</a>
-          </div>
+        <div class="timeline-step text-center">
+          <i class="fa-solid fa-handshake-slash fa-2x mb-2" aria-hidden="true"></i>
+          <div>End Pay-to-Play</div>
         </div>
-        <div class="col-md-6">
-          <div class="info-card h-100">
-            <h3 class="h5 mb-2">Compare the Records</h3>
-            <p class="mb-3">See the incumbent’s results and mine side by side. Facts, votes, and outcomes — clear and sourced.</p>
-            <a class="btn btn-outline-primary" href="/contrast.html"><i class="fa-solid fa-scale-balanced me-1"></i> Learn why we need a change</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- DONATE CTA -->
-  <section class="py-4" style="background:#0b2540; color:#fff;">
-    <div class="container d-flex flex-column flex-md-row align-items-center justify-content-between gap-3">
-      <h3 class="m-0 fw-bold">Power People. Not PACs.</h3>
-      <a class="btn btn-donate" href="https://secure.actblue.com/donate/adam-arafat-1" target="_blank" rel="noopener">
-        <i class="fa-solid fa-heart me-2"></i> Chip in to fuel this campaign
       </a>
+      <a class="btn btn-primary" href="/digging-into-the-issues.html" onclick="track('pact_timeline_click')">Explore the Pact</a>
+    </div>
+  </section>
+
+  <!-- RECORD & CONTRAST -->
+  <section id="contrast" class="section-pad section-alt">
+    <div class="container text-center">
+      <h2 class="section-title mb-3">See the Difference</h2>
+      <p class="lead mb-4">Side-by-side facts on funding sources, votes, and outcomes. Decide for yourself.</p>
+      <a class="btn btn-outline-primary" href="/contrast.html" onclick="track('contrast_cta_click')">Compare Records</a>
+    </div>
+  </section>
+
+  <!-- CTA BAND -->
+  <section class="section-pad text-center" style="background:#0b2540; color:#fff;">
+    <div class="container">
+      <h2 class="fw-bold mb-3">Stand with WA-10</h2>
+      <p class="mb-4">People over PACs. Join the movement.</p>
+      <div class="d-flex flex-column flex-md-row gap-3 justify-content-center">
+        <a class="btn btn-light btn-lg text-primary" href="/contact.html" onclick="track('join_mid_cta')">Join</a>
+        <a class="btn btn-donate btn-lg" href="https://secure.actblue.com/donate/adam-arafat-1" target="_blank" rel="noopener" onclick="track('donate_click_home')">Donate</a>
+      </div>
     </div>
   </section>
 
@@ -241,7 +281,13 @@
   </div>
 </footer>
 
-<script>document.getElementById('yr').textContent = new Date().getFullYear();</script>
+<script>
+  function track(event){
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({event});
+  }
+  document.getElementById('yr').textContent = new Date().getFullYear();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Reworked homepage hero with action-driven copy, background image, and join/read plan CTAs
- Added impact bar, trimmed about section, values list, Evergreen Pact and contrast teasers
- Introduced analytics tracking hooks and refreshed CTA band

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b385a897a48323b9f68fcbe81921e1