### PR TITLE
feat: redesign issues page with staged policy blocks

### DIFF
--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -97,7 +97,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="digging-into-the-issues.html">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link active" href="/Bills/Bills.html" aria-current="page"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>

--- a/Bills/test.html
+++ b/Bills/test.html
@@ -73,7 +73,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="digging-into-the-issues.html">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link active" href="/Bills/Bills.html" aria-current="page"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>

--- a/contact.html
+++ b/contact.html
@@ -196,7 +196,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="/digging-into-the-issues.html">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link active" href="/contact.html" aria-current="page">Contact</a></li>

--- a/contrast.html
+++ b/contrast.html
@@ -156,7 +156,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="/digging-into-the-issues.html">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link active" href="Bills/Bills.html" aria-current="page"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>

--- a/digging-into-the-issues.html
+++ b/digging-into-the-issues.html
@@ -168,7 +168,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="/digging-into-the-issues.html" aria-current="page">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="/digging-into-the-issues.html">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>

--- a/issues.html
+++ b/issues.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <base href="/">
+  <!-- Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TSHYRZVZ97"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);} 
+    gtag('js', new Date());
+    gtag('config', 'G-TSHYRZVZ97');
+  </script>
+
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Issues, Built for Working Families – Adam Neil Arafat</title>
+  <meta name="description" content="Clear fixes for WA-10: lower costs, real healthcare, clean campaigns, fair taxes." />
+  <meta name="theme-color" content="#0d3b66" />
+
+  <!-- Bootstrap + Icons -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+
+  <style>
+    :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; --soft:#f6f9fc; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Arial; }
+    a { text-decoration: none; }
+
+    /* Utilities */
+    .section-pad { padding:4rem 0; }
+    @media (max-width:767.98px){ .section-pad{ padding:2rem 0; } }
+    .section-alt { background:#f8fafc; }
+    .section-title { font-weight:800; color:#0b2540; }
+    .lead { color:#1c2b3a; }
+
+    /* Hero */
+    .hero { background:#0d3b66; color:#fff; }
+    .hero h1 { font-size:2.5rem; }
+    @media (min-width:768px){ .hero h1{font-size:3rem;} }
+
+    /* Impact bar */
+    .impact-item h3{font-size:1.25rem;font-weight:700;}
+    .impact-item p{margin-bottom:0;}
+
+    /* Issue blocks */
+    .issue-block + .issue-block{margin-top:3rem;}
+    .issue-block h2{color:#0b2540;font-weight:700;}
+
+    /* Timeline */
+    .timeline-step i{color:var(--primary);}    
+
+    /* CTA band */
+    .cta-band{background:#0b2540;color:#fff;}
+
+    /* Buttons */
+    .btn-primary { background: var(--primary); border-color: var(--primary); }
+    .btn-primary:hover { background:#0b2f52; border-color:#0b2f52; }
+    .btn-outline-primary { color: var(--primary); border-color: var(--primary); }
+    .btn-outline-primary:hover { background: var(--primary); color:#fff; }
+    .btn:focus-visible { outline:2px solid #000; outline-offset:2px; }
+    .btn-donate { background: var(--donate); color:#fff; border:0; border-radius:999px; padding:.65rem 1.2rem; font-weight:800; box-shadow:0 6px 16px rgba(193,18,31,.25); }
+    .btn-donate:hover { transform: translateY(-1px); box-shadow:0 8px 20px rgba(193,18,31,.35); color:#fff; }
+
+    /* Social bar */
+    .social-top { background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%); color:#fff; }
+    .social-pill { display:inline-flex; align-items:center; gap:.5rem; padding:.5rem .9rem; border-radius:999px; border:1px solid rgba(255,255,255,.25); color:#fff; background: rgba(255,255,255,.08); backdrop-filter: blur(4px); font-weight:700; }
+    .social-pill:hover { transform: translateY(-1px); background: rgba(255,255,255,.16); box-shadow: 0 6px 16px rgba(0,0,0,.15); color:#fff; }
+    .bsky-icon { width:18px; height:18px; vertical-align:-2px; }
+
+    /* Header pills */
+    .header-break { background:#0d3b66; color:#fff; padding:1rem; display:flex; flex-wrap:wrap; gap:.5rem; justify-content:center; text-align:center; }
+    .header-break .pill { display:inline-block; padding:.4rem .9rem; border-radius:999px; background: rgba(255,255,255,.12); border:1px solid rgba(255,255,255,.25); font-weight:800; white-space:nowrap; }
+    @media (max-width: 767.98px){ .header-break{ flex-direction:column; align-items:center; } .header-break .pill{ display:block; width:100%; max-width:320px; white-space:normal; line-height:1.2; word-break:break-word; overflow-wrap:anywhere; text-align:center; } }
+
+    /* Navbar underline hover */
+    .navbar .nav-link { position: relative; padding:.25rem .5rem; color:#1c2b3a; font-weight:600; }
+    .navbar .nav-link:hover { color: var(--link); }
+    .navbar .nav-link::after { content:""; position:absolute; left:0; bottom:-4px; height:2px; width:0; background: currentColor; border-radius:2px; transition: width .18s ease; }
+    .navbar .nav-link:hover::after, .navbar .nav-link:focus::after, .navbar .nav-link[aria-current="page"]::after { width:100%; }
+  </style>
+</head>
+<body>
+<a class="visually-hidden-focusable" href="#main">Skip to content</a>
+
+<!-- SOCIAL BAR -->
+<section class="social-top py-2">
+  <div class="container d-flex flex-wrap justify-content-center gap-2">
+    <a class="social-pill" href="https://www.reddit.com/u/adam_neil_arafat/s/HkHlNPDrbo" target="_blank" rel="noopener"><i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span></a>
+    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Bluesky">
+      <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
+      <span>Bluesky</span>
+    </a>
+    <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa8?_t=ZT-8yve7Bzjrd0&_r=1" target="_blank" rel="noopener"><i class="fa-brands fa-tiktok"></i> <span>TikTok</span></a>
+  </div>
+</section>
+
+<!-- HEADER PILLS -->
+<div class="header-break">
+  <span class="pill">Trust is built, not bought.</span>
+  <span class="pill">WA-10 deserves a fighter for working families</span>
+  <span class="pill">For Working Families. For WA-10.</span>
+</div>
+
+<!-- NAV -->
+<nav class="navbar navbar-expand-lg bg-white border-bottom sticky-top" aria-label="Main">
+  <div class="container">
+    <a class="navbar-brand fw-bold" href="/index.html">Adam Neil Arafat for Congress - WA-10</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navMenu">
+      <ul class="navbar-nav ms-auto align-items-lg-center">
+        <li class="nav-item"><a class="nav-link" href="/issues.html" aria-current="page">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
+        <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
+        <li class="nav-item"><a class="nav-link" href="/contact.html">Contact</a></li>
+        <li class="nav-item ms-lg-3"><a class="btn btn-primary" href="/contact.html">Join the Movement</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<main id="main">
+
+  <!-- HERO -->
+  <section class="hero d-flex align-items-center text-center">
+    <div class="container">
+      <h1 class="fw-bold mb-3">Issues, Built for Working Families</h1>
+      <p class="lead mb-4">Clear fixes for WA-10: lower costs, real healthcare, clean campaigns, fair taxes.</p>
+      <div class="d-flex flex-column flex-md-row gap-3 justify-content-center">
+        <a class="btn btn-light btn-lg text-primary" href="/digging-into-the-issues.html" onclick="track('issues_hero_pact_click')">Explore the Pact</a>
+        <a class="btn btn-outline-light btn-lg" href="/contrast.html" onclick="track('issues_hero_contrast_click')">Compare Records</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- IMPACT BAR -->
+  <section class="impact-bar section-pad section-alt">
+    <div class="container">
+      <div class="row g-3 text-center">
+        <div class="col-md-4 impact-item">
+          <h3>Lower Costs First</h3>
+          <p>Housing, groceries, childcare, energy.</p>
+        </div>
+        <div class="col-md-4 impact-item">
+          <h3>Healthcare That Works</h3>
+          <p>Access, simplicity, no surprises.</p>
+        </div>
+        <div class="col-md-4 impact-item">
+          <h3>Clean Campaigns</h3>
+          <p>People over PACs, full transparency.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ISSUE BLOCKS -->
+  <section class="section-pad">
+    <div class="container">
+      <div class="issue-block">
+        <h2>Lowering the Cost of Living</h2>
+        <p><strong>Problem:</strong> Families are getting squeezed by housing, groceries, childcare, and energy bills.</p>
+        <p><strong>Plan:</strong></p>
+        <ul>
+          <li>Speed housing permits and build near transit.</li>
+          <li>Cut junk fees and price games at the register.</li>
+          <li>Expand childcare support so parents can work.</li>
+          <li>Help families lower energy bills with upgrades.</li>
+          <li>Protect Social Security you earned.</li>
+        </ul>
+        <p><strong>Result in WA-10:</strong> A fair shot to live and stay in our communities.</p>
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-primary btn-sm" href="/digging-into-the-issues.html#cost-of-living" onclick="track('issues_block_readplan_click',{label:'cost'})">Read the Plan</a>
+          <a class="btn btn-outline-primary btn-sm" href="/digging-into-the-issues.html">Explore the Pact</a>
+        </div>
+      </div>
+
+      <div class="issue-block">
+        <h2>Healthcare You Can Use</h2>
+        <p><strong>Problem:</strong> Care is complex, expensive, and easy to lose when life shifts.</p>
+        <p><strong>Plan:</strong></p>
+        <ul>
+          <li>Universal coverage with simple enrollment.</li>
+          <li>Primary-care first, no surprise bills.</li>
+          <li>Lower drug costs and hospital prices.</li>
+          <li>Protect veterans’ care and rural access.</li>
+        </ul>
+        <p><strong>Result in WA-10:</strong> Doctor first, paperwork last—so people actually get care.</p>
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-primary btn-sm" href="/digging-into-the-issues.html#healthcare" onclick="track('issues_block_readplan_click',{label:'healthcare'})">Read the Plan</a>
+          <a class="btn btn-outline-primary btn-sm" href="/digging-into-the-issues.html">Explore the Pact</a>
+        </div>
+      </div>
+
+      <div class="issue-block">
+        <h2>Clean Campaigns &amp; Anti-Corruption</h2>
+        <p><strong>Problem:</strong> Big donors and outside money tilt priorities away from WA-10.</p>
+        <p><strong>Plan:</strong></p>
+        <ul>
+          <li>Ban corporate PAC money; disclose dark money.</li>
+          <li>Strengthen small-donor power and transparency.</li>
+          <li>Close lobbyist loopholes and end pay-to-play.</li>
+        </ul>
+        <p><strong>Result in WA-10:</strong> Decisions for neighbors, not national networks.</p>
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-primary btn-sm" href="/digging-into-the-issues.html#clean-campaigns" onclick="track('issues_block_readplan_click',{label:'clean_campaigns'})">Read the Plan</a>
+          <a class="btn btn-outline-primary btn-sm" href="/contrast.html">Compare Records</a>
+        </div>
+      </div>
+
+      <div class="issue-block">
+        <h2>Fair Economy &amp; Tax Commonsense</h2>
+        <p><strong>Problem:</strong> The rules reward those at the top while working families carry more of the load.</p>
+        <p><strong>Plan:</strong></p>
+        <ul>
+          <li>Tax fairness that protects working- and middle-class families.</li>
+          <li>Support training and local jobs that actually pay.</li>
+          <li>Reward small business and made-here work.</li>
+        </ul>
+        <p><strong>Result in WA-10:</strong> A fair economy that grows from the middle out.</p>
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-primary btn-sm" href="/digging-into-the-issues.html#fair-economy" onclick="track('issues_block_readplan_click',{label:'fair_economy'})">Read the Plan</a>
+          <a class="btn btn-outline-primary btn-sm" href="/digging-into-the-issues.html">Explore the Pact</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- EVERGREEN PACT TEASER -->
+  <section class="section-pad text-center section-alt">
+    <div class="container">
+      <a href="/digging-into-the-issues.html" class="d-flex flex-column flex-md-row gap-4 justify-content-center align-items-start text-decoration-none text-body mb-4" aria-label="Explore the Evergreen Pact">
+        <div class="timeline-step text-center">
+          <div class="fw-bold">Phase 1</div>
+          <div>Lower costs</div>
+        </div>
+        <div class="timeline-step text-center">
+          <div class="fw-bold">Phase 2</div>
+          <div>Healthcare</div>
+        </div>
+        <div class="timeline-step text-center">
+          <div class="fw-bold">Phase 3</div>
+          <div>End pay-to-play</div>
+        </div>
+      </a>
+      <p class="lead mb-4">A focused sequence of bill blueprints to notch early wins, build leverage, then take on the hardest fights.</p>
+      <a class="btn btn-primary" href="/digging-into-the-issues.html">Explore the Pact</a>
+    </div>
+  </section>
+
+  <!-- SOURCES -->
+  <section class="section-pad" id="sources">
+    <div class="container">
+      <h2 class="h4 section-title">Sources &amp; References</h2>
+      <p class="mb-3">Based on leading health, economic, and democracy research, plus FEC filings for transparency.</p>
+      <p class="small mb-3"><a href="https://www.fec.gov/data/committee/C00914705/" target="_blank" rel="noopener">Committee profile on the FEC</a></p>
+      <button class="btn btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#sourceList" aria-expanded="false" aria-controls="sourceList">Show full sources</button>
+      <div class="collapse mt-3" id="sourceList">
+        <ul class="small mb-3">
+          <li><a href="https://www.oecd.org/en/topics/health-inequality-and-universal-health-coverage.html" target="_blank" rel="noopener">OECD: Universal coverage and health outcomes</a></li>
+          <li><a href="https://www.commonwealthfund.org/publications/issue-briefs/2023/jan/us-health-care-global-perspective-2022" target="_blank" rel="noopener">Commonwealth Fund: U.S. health care in global perspective</a></li>
+          <li><a href="https://www.seattle.gov/democracyvoucher" target="_blank" rel="noopener">City of Seattle: Democracy Voucher Program</a></li>
+          <li><a href="https://www.dol.gov/agencies/whd/minimum-wage" target="_blank" rel="noopener">U.S. Department of Labor: Minimum wage history</a></li>
+          <li><a href="https://www.epi.org" target="_blank" rel="noopener">Economic Policy Institute: CEO-to-worker pay ratio</a></li>
+          <li><a href="https://itep.org" target="_blank" rel="noopener">Institute on Taxation and Economic Policy</a></li>
+          <li><a href="https://www.bls.gov/cpi/" target="_blank" rel="noopener">Bureau of Labor Statistics: CPI</a></li>
+          <li><a href="https://www.ers.usda.gov/topics/food-markets-prices/food-prices-outlook/" target="_blank" rel="noopener">USDA ERS: Food Prices Outlook</a></li>
+          <li><a href="https://www.childcareaware.org" target="_blank" rel="noopener">Child Care Aware: Cost and availability</a></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA BAND -->
+  <section class="cta-band section-pad text-center">
+    <div class="container">
+      <h2 class="fw-bold mb-3">Ready to Build It?</h2>
+      <p class="mb-4">Join a people-powered campaign for WA-10.</p>
+      <div class="d-flex flex-column flex-md-row gap-3 justify-content-center">
+        <a class="btn btn-light btn-lg text-primary" href="/contact.html" onclick="track('issues_cta_join_click')">Join</a>
+        <a class="btn btn-donate btn-lg" href="https://secure.actblue.com/donate/adam-arafat-1" target="_blank" rel="noopener" onclick="track('issues_cta_donate_click')">Donate</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="py-4 bg-white border-top text-center">
+  <div class="container">
+    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
+    <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
+    <p class="small text-muted mb-3">Not authorized by any other candidate or candidate's committee</p>
+  </div>
+</footer>
+
+<script>
+  function track(event, extra={}){
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({event, ...extra});
+  }
+  document.getElementById('yr').textContent = new Date().getFullYear();
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/test.html
+++ b/test.html
@@ -95,7 +95,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navMenu">
       <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link" href="../digging-into-the-issues.html">Issues</a></li>
+        <li class="nav-item"><a class="nav-link" href="/issues.html">Issues</a></li>
         <li class="nav-item"><a class="nav-link active" href="Bills/Bills.html" aria-current="page"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="../contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link" href="../contact.html">Contact</a></li>


### PR DESCRIPTION
## Summary
- add new `issues.html` landing with hero, impact bar, and four skimmable issue blocks
- include Evergreen Pact teaser, collapsible sources, and CTA band
- update navigation links across site to point to new Issues page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3872dd24883238ac62d65e0cba4ae