### PR TITLE
feat: tighten site spacing and mobile two-up layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>404 — Page Not Found</title>
+  <link rel="stylesheet" href="assets/css/compact.css" />
   <style>
     body{background:#f6f9fc;color:#0d3b66;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;text-align:center;padding:3rem}
     img{max-width:80%;height:auto;border-radius:8px;box-shadow:0 6px 20px rgba(13,59,102,.15)}

--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -19,6 +19,7 @@
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet"/>
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root{

--- a/Overview.html
+++ b/Overview.html
@@ -9,6 +9,7 @@
   <meta name="theme-color" content="#0d3b66" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet"/>
+  <link rel="stylesheet" href="assets/css/compact.css" />
   <style>
     :root{ --primary:#0d3b66; --soft:#f6f9fc; --ink:#1b2634;
            --t0:#284b63; --t1:#0b6e4f; --t2:#0d3b66; --t3:#7a3e9d; --t4:#1f6feb; --t5:#c1121f; }

--- a/assets/css/compact.css
+++ b/assets/css/compact.css
@@ -1,0 +1,72 @@
+/* ===== Compact, cleaner spacing ===== */
+:root{
+  --space-1: .25rem;
+  --space-2: .5rem;
+  --space-3: .75rem;
+  --space-4: 1rem;
+  --radius: 12px;
+}
+
+html{ scroll-behavior:smooth; }
+body{ line-height: 1.45; }
+
+:where(h1,h2,h3,h4){ margin: 0 0 .5em; line-height: 1.15; }
+:where(p,ul,ol){ margin: 0 0 .75em; }
+small, .eyebrow { opacity:.9; }
+
+/* Sections and containers */
+.section{ padding-block: clamp(16px, 2.5vw, 32px); }
+.container{ max-width: 1100px; padding-inline: clamp(12px,2vw,24px); margin-inline:auto; }
+
+/* Grids and gaps */
+.grid{ display:grid; gap: clamp(8px,2vw,16px); }
+.grid-3{ grid-template-columns: repeat(3, minmax(0,1fr)); }
+/* Tablet collapses to two-up */
+@media (max-width: 1024px){ .grid-3{ grid-template-columns: repeat(2,1fr); } }
+/* Mobile keeps two-up when possible */
+@media (max-width: 480px){ .grid-3{ grid-template-columns: repeat(2,1fr); } }
+/* Very narrow phones fall back to single */
+@media (max-width: 359px){ .grid-3{ grid-template-columns: 1fr; } }
+
+/* Cards tighten */
+.cards-compact .card{
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(0,0,0,.08);
+}
+.cards-compact .card h3{
+  margin-bottom: .4rem;
+  font-size: clamp(1rem,2.3vw,1.2rem);
+}
+.cards-compact .card p{ margin: 0; }
+
+/* Hero trims */
+.hero{ min-height: 42vh; padding-block: clamp(24px,3vw,48px); }
+.hero .content{ max-width: 800px; }
+.hero img{ height: 42vh; object-fit: cover; }
+
+/* Nav/Footer trims */
+.nav{ padding-block: 8px; }
+.nav a{ padding: 6px 10px; }
+.footer{ padding-block: 16px; }
+
+/* Lists and buttons */
+.list-compact li{ margin-bottom: .4rem; }
+.button{ padding: 8px 12px; line-height: 1.1; }
+
+/* ===== Mobile left/right two-up helper ===== */
+.mobile-split{
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+@media (max-width: 359px){
+  .mobile-split{ grid-template-columns: 1fr; }
+}
+
+/* Icon + text helper for tight rows */
+.icon-left{ display:flex; gap: 10px; align-items:flex-start; }
+.icon-left img{ width: 28px; height:28px; margin-top:2px; }
+
+/* Safety reducer for any oversized utility classes in markup */
+.reduce-margins :is(.mt-12,.mb-12,.py-20){ margin: 1rem 0 !important; padding-block: 2rem !important; }

--- a/contact.html
+++ b/contact.html
@@ -36,6 +36,7 @@
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; }

--- a/contrast.html
+++ b/contrast.html
@@ -22,6 +22,7 @@
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --ink:#10324f; --soft:#f6f9fc; }

--- a/digging-into-the-issues.html
+++ b/digging-into-the-issues.html
@@ -20,6 +20,7 @@
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; }

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; --soft:#f6f9fc; }
@@ -18,8 +19,6 @@
     a { text-decoration: none; }
 
     /* Utilities */
-    .section-pad { padding:4rem 0; }
-    @media (max-width:767.98px){ .section-pad{ padding:2rem 0; } }
     .section-alt { background:#f8fafc; }
     .section-title { font-weight:800; color:#0b2540; }
     .lead { color:#1c2b3a; }
@@ -38,9 +37,6 @@
 
     /* Values icons hidden on mobile */
     @media (max-width:767.98px){ .values-list i{display:none;} }
-
-    /* Timeline */
-    .timeline-step i{color:var(--primary);}
 
     /* Social bar */
     .social-top { background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%); color:#fff; }
@@ -181,7 +177,7 @@
   </section>
 
   <!-- IMPACT BAR -->
-  <section class="impact-bar section-pad section-alt">
+  <section class="impact-bar section section-alt">
     <div class="container">
       <div class="row g-3 text-center">
         <div class="col-md-4 impact-item">
@@ -201,12 +197,12 @@
   </section>
 
   <!-- ABOUT -->
-  <section id="about" class="section-pad">
+  <section id="about" class="section">
     <div class="container">
       <h2 class="section-title mb-4">About Adam</h2>
       <div class="row align-items-center g-4">
         <div class="col-md-5 text-center">
-          <img class="about-photo img-fluid" src="images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" alt="Adam Neil Arafat headshot" loading="lazy">
+          <img class="about-photo img-fluid" src="images/assets_task_01k3ym6w4wehnr08xx0aw81ede_1756595820_img_0.webp" alt="Adam Neil Arafat headshot" loading="lazy">
         </div>
         <div class="col-md-7">
           <p>I served 20 years in the Army and now work to keep our local infrastructure running so families in WA-10 have reliable services every day. I’m a husband and dad, raising kids in our public schools.</p>
@@ -225,30 +221,30 @@
   </section>
 
   <!-- EVERGREEN PACT -->
-  <section id="pact" class="section-pad">
+  <section id="pact" class="section">
     <div class="container text-center">
       <h2 class="section-title mb-3">The Evergreen Pact</h2>
       <p class="lead mb-4">A focused sequence of bill blueprints to notch early wins, build leverage, then tackle the hardest fights.</p>
-      <a href="/digging-into-the-issues.html" class="d-flex flex-column flex-md-row gap-4 justify-content-center align-items-start text-decoration-none text-body mb-4" onclick="track('pact_timeline_click')" aria-label="Explore the Evergreen Pact">
-        <div class="timeline-step text-center">
-          <i class="fa-solid fa-arrow-down fa-2x mb-2" aria-hidden="true"></i>
-          <div>Lower Costs</div>
-        </div>
-        <div class="timeline-step text-center">
-          <i class="fa-solid fa-stethoscope fa-2x mb-2" aria-hidden="true"></i>
-          <div>Universal Healthcare</div>
-        </div>
-        <div class="timeline-step text-center">
-          <i class="fa-solid fa-handshake-slash fa-2x mb-2" aria-hidden="true"></i>
-          <div>End Pay-to-Play</div>
-        </div>
-      </a>
-      <a class="btn btn-primary" href="/digging-into-the-issues.html" onclick="track('pact_timeline_click')">Explore the Pact</a>
+      <div class="mobile-split" aria-label="Top priorities">
+        <a href="/digging-into-the-issues.html#lower-costs" class="card text-decoration-none text-body">
+          <h3>Lower Costs</h3>
+          <p>Cut expenses for working families.</p>
+        </a>
+        <a href="/digging-into-the-issues.html#universal-healthcare" class="card text-decoration-none text-body">
+          <h3>Universal Healthcare</h3>
+          <p>Guarantee care without crippling bills.</p>
+        </a>
+        <a href="/digging-into-the-issues.html#end-pay-to-play" class="card text-decoration-none text-body">
+          <h3>End Pay-to-Play</h3>
+          <p>Ban corporate and PAC influence.</p>
+        </a>
+      </div>
+      <a class="btn btn-primary mt-3" href="/digging-into-the-issues.html" onclick="track('pact_timeline_click')">Explore the Pact</a>
     </div>
   </section>
 
   <!-- RECORD & CONTRAST -->
-  <section id="contrast" class="section-pad section-alt">
+  <section id="contrast" class="section section-alt">
     <div class="container text-center">
       <h2 class="section-title mb-3">See the Difference</h2>
       <p class="lead mb-4">Side-by-side facts on funding sources, votes, and outcomes. Decide for yourself.</p>
@@ -257,7 +253,7 @@
   </section>
 
   <!-- CTA BAND -->
-  <section class="section-pad text-center" style="background:#0b2540; color:#fff;">
+  <section class="section text-center" style="background:#0b2540; color:#fff;">
     <div class="container">
       <h2 class="fw-bold mb-3">Stand with WA-10</h2>
       <p class="mb-4">People over PACs. Join the movement.</p>

--- a/issues.html
+++ b/issues.html
@@ -20,6 +20,7 @@
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; --soft:#f6f9fc; }
@@ -27,8 +28,6 @@
     a { text-decoration: none; }
 
     /* Utilities */
-    .section-pad { padding:4rem 0; }
-    @media (max-width:767.98px){ .section-pad{ padding:2rem 0; } }
     .section-alt { background:#f8fafc; }
     .section-title { font-weight:800; color:#0b2540; }
     .lead { color:#1c2b3a; }
@@ -45,9 +44,6 @@
     /* Issue blocks */
     .issue-block + .issue-block{margin-top:3rem;}
     .issue-block h2{color:#0b2540;font-weight:700;}
-
-    /* Timeline */
-    .timeline-step i{color:var(--primary);}    
 
     /* CTA band */
     .cta-band{background:#0b2540;color:#fff;}
@@ -135,7 +131,7 @@
   </section>
 
   <!-- IMPACT BAR -->
-  <section class="impact-bar section-pad section-alt">
+  <section class="impact-bar section section-alt">
     <div class="container">
       <div class="row g-3 text-center">
         <div class="col-md-4 impact-item">
@@ -155,7 +151,7 @@
   </section>
 
   <!-- ISSUE BLOCKS -->
-  <section class="section-pad">
+  <section class="section">
     <div class="container">
       <div class="issue-block">
         <h2>Lowering the Cost of Living</h2>
@@ -227,29 +223,29 @@
   </section>
 
   <!-- EVERGREEN PACT TEASER -->
-  <section class="section-pad text-center section-alt">
+  <section class="section text-center section-alt cards-compact">
     <div class="container">
-      <a href="/digging-into-the-issues.html" class="d-flex flex-column flex-md-row gap-4 justify-content-center align-items-start text-decoration-none text-body mb-4" aria-label="Explore the Evergreen Pact">
-        <div class="timeline-step text-center">
-          <div class="fw-bold">Phase 1</div>
-          <div>Lower costs</div>
-        </div>
-        <div class="timeline-step text-center">
-          <div class="fw-bold">Phase 2</div>
-          <div>Healthcare</div>
-        </div>
-        <div class="timeline-step text-center">
-          <div class="fw-bold">Phase 3</div>
-          <div>End pay-to-play</div>
-        </div>
-      </a>
+      <div class="mobile-split mb-4" aria-label="Evergreen Pact phases">
+        <a href="/digging-into-the-issues.html#lower-costs" class="card text-decoration-none text-body">
+          <h3>Phase 1</h3>
+          <p>Lower costs</p>
+        </a>
+        <a href="/digging-into-the-issues.html#universal-healthcare" class="card text-decoration-none text-body">
+          <h3>Phase 2</h3>
+          <p>Healthcare</p>
+        </a>
+        <a href="/digging-into-the-issues.html#end-pay-to-play" class="card text-decoration-none text-body">
+          <h3>Phase 3</h3>
+          <p>End pay-to-play</p>
+        </a>
+      </div>
       <p class="lead mb-4">A focused sequence of bill blueprints to notch early wins, build leverage, then take on the hardest fights.</p>
       <a class="btn btn-primary" href="/digging-into-the-issues.html">Explore the Pact</a>
     </div>
   </section>
 
   <!-- SOURCES -->
-  <section class="section-pad" id="sources">
+  <section class="section" id="sources">
     <div class="container">
       <h2 class="h4 section-title">Sources &amp; References</h2>
       <p class="mb-3">Based on leading health, economic, and democracy research, plus FEC filings for transparency.</p>
@@ -272,7 +268,7 @@
   </section>
 
   <!-- CTA BAND -->
-  <section class="cta-band section-pad text-center">
+  <section class="cta-band section text-center">
     <div class="container">
       <h2 class="fw-bold mb-3">Ready to Build It?</h2>
       <p class="mb-4">Join a people-powered campaign for WA-10.</p>

--- a/meet-adam.html
+++ b/meet-adam.html
@@ -11,6 +11,7 @@
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/compact.css" />
 
   <style>
     :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; --soft:#f6f9fc; }
@@ -18,10 +19,10 @@
     a { text-decoration: none; }
 
     /* Utilities */
-    .section-pad { padding:4rem 0; }
-    @media (max-width:767.98px){ .section-pad{ padding:2rem 0; } }
     .section-title { font-weight:800; color:#0b2540; }
     .lead { color:#1c2b3a; }
+    /* Values icons hidden on mobile */
+    @media (max-width:767.98px){ .values-list i{display:none;} }
 
     /* Social bar */
     .social-top { background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%); color:#fff; }
@@ -126,7 +127,7 @@
 </nav>
 
 <main id="main">
-  <section class="section-pad">
+  <section class="section">
     <div class="container">
       <h1 class="section-title mb-4">Meet Adam</h1>
       <p class="lead">I’m Adam Neil Arafat. I’ve spent my life serving my country, my community, and my family. Now I’m asking to serve you in Congress.</p>
@@ -150,6 +151,13 @@
       </ul>
 
       <p class="mt-4">This campaign is not about me. It is about us. Our voices, our struggles, and our future.</p>
+
+      <h2 class="mt-4 mb-3">Values</h2>
+      <ul class="values-list list-unstyled mb-0">
+        <li class="mb-2"><i class="fa-solid fa-check text-success me-2"></i><strong>Service</strong> — Country, community, family.</li>
+        <li class="mb-2"><i class="fa-solid fa-check text-success me-2"></i><strong>Accountability</strong> — No PAC money. No corporate strings.</li>
+        <li><i class="fa-solid fa-check text-success me-2"></i><strong>Fairness</strong> — Policies that put working families first.</li>
+      </ul>
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- add compact spacing styles and mobile two-up helper
- restructure Evergreen Pact priorities into mobile-split cards
- replace home about photo and copy values into Meet Adam page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b395f413488323b792516e3104f60d