### PR TITLE
Refresh contact page with focused CTAs and mailto routing

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -7,14 +7,15 @@
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date()); gtag('config', 'G-TSHYRZVZ97');
+    gtag('js', new Date());
+    gtag('config', 'G-TSHYRZVZ97');
   </script>
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contact – Adam Neil Arafat for Congress (WA-10)</title>
   <meta name="theme-color" content="#0d3b66" />
-  <meta name="description" content="Email the campaign, volunteer, or share your story with Adam Neil Arafat for Congress (WA-10).">
+  <meta name="description" content="Email the campaign, invite Adam to an event, or share your story with Adam Neil Arafat for Congress (WA-10)." />
 
   <script type="application/ld+json">
   {
@@ -34,142 +35,47 @@
   </script>
 
   <!-- Bootstrap + Icons -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
 
   <style>
-    :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; }
-
+    :root { --primary:#0d3b66; --donate:#c1121f; --accent:#0b6e4f; --link:#0d3b66; --soft:#f6f9fc; }
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Arial; }
     a { text-decoration: none; }
 
-    /* Top social bar */
-    .social-top {
-      background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%);
-      color: #fff;
-    }
-    .social-pill {
-      display:inline-flex; align-items:center; gap:.5rem; padding:.5rem .9rem;
-      border-radius:999px; border:1px solid rgba(255,255,255,.25); color:#fff; text-decoration:none;
-      background: rgba(255,255,255,.08); backdrop-filter: blur(4px);
-      transition: transform .08s ease, background .15s ease, box-shadow .15s ease;
-      font-weight:700;
-    }
-    .social-pill:hover { transform: translateY(-1px); background: rgba(255,255,255,.16); box-shadow: 0 6px 16px rgba(0,0,0,.15); color:#fff; }
+    /* Social bar */
+    .social-top { background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%); color:#fff; }
+    .social-pill { display:inline-flex; align-items:center; gap:.5rem; padding:.5rem .9rem; border-radius:999px; border:1px solid rgba(255,255,255,.25); color:#fff; background:rgba(255,255,255,.08); backdrop-filter:blur(4px); font-weight:700; transition:transform .08s ease, background .15s ease, box-shadow .15s ease; }
+    .social-pill:hover { transform:translateY(-1px); background:rgba(255,255,255,.16); box-shadow:0 6px 16px rgba(0,0,0,.15); color:#fff; }
     .bsky-icon { width:18px; height:18px; vertical-align:-2px; }
 
-    /* Header break band */
-    .header-break {
-      background:#0d3b66; color:#fff; text-align:center; padding:.9rem 1rem;
-    }
-    .header-break .kicker { margin:0; font-weight:800; letter-spacing:.2px; text-transform:uppercase; }
-    .header-break p { margin:.35rem 0 0; font-weight:500; opacity:.95; }
+    /* Header break */
+    .header-break { background:#0d3b66; color:#fff; padding:1rem; display:flex; flex-wrap:wrap; gap:.5rem; justify-content:center; text-align:center; }
+    .header-break .pill { display:inline-block; padding:.4rem .9rem; border-radius:999px; background:rgba(255,255,255,.12); border:1px solid rgba(255,255,255,.25); font-weight:800; white-space:nowrap; }
+    @media (max-width:767.98px){ .header-break{ flex-direction:column; align-items:center; } .header-break .pill{ display:block; width:100%; max-width:320px; white-space:normal; line-height:1.2; word-break:break-word; overflow-wrap:anywhere; text-align:center; } }
 
-    /* Rally "pills" */
-    .rallies {
-      display:flex; gap:.5rem; flex-wrap:wrap; justify-content:center; margin:.5rem 0 0;
-    }
-    .rallies span {
-      display:inline-block;
-      background: rgba(255,255,255,.12);
-      border:1px solid rgba(255,255,255,.25);
-      padding:.2rem .55rem;
-      border-radius:999px;
-      font-weight:700;
-      white-space: nowrap; /* single-line on wider screens */
-    }
-    @media (max-width: 767.98px){
-      .rallies span{
-        display:block;
-        white-space: normal;       /* allow wrapping */
-        max-width: 320px;
-        margin: 0 auto;            /* centered full-width pill */
-        line-height: 1.2;
-        word-break: break-word;
-        overflow-wrap: anywhere;
-        text-align: center;
-      }
-    }
-
-    /* Pretty nav links: subtle animated underline */
-    .navbar .nav-link {
-      position: relative;
-      padding: .25rem .5rem;
-      color: #1c2b3a;
-      font-weight: 600;
-    }
-    .navbar .nav-link:hover { color: var(--link); }
-    .navbar .nav-link::after {
-      content:"";
-      position:absolute; left:0; bottom:-4px; height:2px; width:0;
-      background: currentColor; border-radius:2px; transition: width .18s ease;
-    }
+    /* Navbar underline */
+    .navbar .nav-link { position:relative; padding:.25rem .5rem; color:#1c2b3a; font-weight:600; }
+    .navbar .nav-link:hover { color:var(--link); }
+    .navbar .nav-link::after { content:""; position:absolute; left:0; bottom:-4px; height:2px; width:0; background:currentColor; border-radius:2px; transition:width .18s ease; }
     .navbar .nav-link:hover::after, .navbar .nav-link:focus::after, .navbar .nav-link[aria-current="page"]::after { width:100%; }
 
-    /* Utility + page sections */
-    .section-title { color: var(--primary); }
-    .divider { border-top:2px solid #e9eef3; margin:3rem 0 1.25rem; }
+    /* Hero */
+    .hero { background-image:url('images/Tacoma-narrows-bridge-image-8.jpg'); background-position:center; background-size:cover; background-repeat:no-repeat; }
+    .hero .wrap { background:linear-gradient(0deg, rgba(13,59,102,.68), rgba(13,59,102,.68)); color:#fff; border-radius:14px; }
 
-    /* Contact cards */
-    .contact-card {
-      border:1px solid #e9eef3; background:#f8fafc; border-radius:14px; padding:1.25rem;
-      box-shadow:0 6px 16px rgba(13,59,102,.06); height:100%;
-      transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease;
-    }
-    .contact-card:hover {
-      transform: translateY(-2px);
-      box-shadow:0 12px 28px rgba(13,59,102,.12);
-      border-color:#d8e4ee;
-    }
-    .contact-card .icon {
-      width:42px; height:42px; display:inline-flex; align-items:center; justify-content:center;
-      border-radius:10px; background:#e6f0f8; color:#0d3b66; margin-right:.5rem;
-    }
+    /* Buttons */
+    .btn-primary { background:var(--primary); border-color:var(--primary); }
+    .btn-primary:hover { background:#0b2f52; border-color:#0b2f52; }
+    .btn-outline-primary { color:var(--primary); border-color:var(--primary); }
+    .btn-outline-primary:hover { background:var(--primary); color:#fff; }
+    .btn-donate { background:var(--donate); color:#fff; border:0; border-radius:999px; padding:.65rem 1.2rem; font-weight:800; letter-spacing:.2px; box-shadow:0 6px 16px rgba(193,18,31,.25); transition:transform .07s ease, box-shadow .15s ease, opacity .15s ease; white-space:nowrap; }
+    .btn-donate:hover { transform:translateY(-1px); box-shadow:0 8px 20px rgba(193,18,31,.35); color:#fff; }
 
-    /* Hero banner (subtle image tint) */
-    .hero {
-      background-image: url('images/Tacoma-narrows-bridge-image-8.jpg');
-      background-position:center; background-size:cover; background-repeat:no-repeat;
-    }
-    .hero .wrap {
-      background: linear-gradient(0deg, rgba(13,59,102,.68), rgba(13,59,102,.68));
-      color:#fff; border-radius:14px;
-    }
-
-    /* Story box */
-    .story-box {
-      border:1px solid #e9eef3; border-radius:14px; padding:1.25rem; background:#ffffff;
-      box-shadow:0 6px 16px rgba(13,59,102,.06);
-    }
-    .form-control:focus { box-shadow: 0 0 0 .2rem rgba(13,59,102,.15); border-color:#bcd0e1; }
-
-    /* Donate button (consistent sitewide) */
-    .btn-donate {
-      background: var(--donate);
-      color:#fff;
-      border: 0;
-      border-radius: 999px;
-      padding: .65rem 1.2rem;
-      font-weight: 800;
-      letter-spacing:.2px;
-      box-shadow: 0 6px 16px rgba(193, 18, 31, .25);
-      transition: transform .07s ease, box-shadow .15s ease, opacity .15s ease;
-      white-space: nowrap;
-    }
-    .btn-donate:hover { transform: translateY(-1px); box-shadow: 0 8px 20px rgba(193,18,31,.35); color:#fff; }
-
-    /* Footer: social row + legal */
-    .footer-social {
-      background: linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%);
-      color: #fff;
-    }
-    .footer-social .social-pill {
-      border-color: rgba(255,255,255,.3);
-      background: rgba(255,255,255,.10);
-    }
-    .footer-legal {
-      background:#ffffff;
-    }
+    /* Footer */
+    .footer-social { background:linear-gradient(90deg, #0d3b66 0%, #0b6e4f 50%, #0d3b66 100%); color:#fff; }
+    .footer-social .social-pill { border-color:rgba(255,255,255,.3); background:rgba(255,255,255,.10); }
+    .footer-legal { background:#ffffff; }
   </style>
 </head>
 <body>
@@ -178,34 +84,29 @@
 <!-- SOCIAL MEDIA BAR -->
 <section class="social-top py-2">
   <div class="container d-flex flex-wrap justify-content-center gap-2">
-    <a class="social-pill" href="https://www.reddit.com/user/adam_neil_arafat" target="_blank" rel="noopener" aria-label="Follow Adam on Reddit">
+    <span class="me-2 fw-semibold">Follow Adam:</span>
+    <a class="social-pill" href="https://www.reddit.com/user/adam_neil_arafat" target="_blank" rel="noopener" aria-label="Reddit">
       <i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span>
     </a>
-    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Follow Adam on Bluesky">
+    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Bluesky">
       <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
       <span>Bluesky</span>
     </a>
-    <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa10" target="_blank" rel="noopener" aria-label="Follow Adam on TikTok">
+    <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa10" target="_blank" rel="noopener" aria-label="TikTok">
       <i class="fa-brands fa-tiktok"></i> <span>TikTok</span>
     </a>
   </div>
 </section>
 
-<!-- HEADER BREAK (wrapped in container for better line length) -->
+<!-- VALUE TAGLINES -->
 <div class="header-break">
-  <div class="container">
-    <p class="kicker">Get in Touch</p>
-    <p>This is a grassroots campaign. I work full time and have a family, so I may be slow to respond, but I read every message. Thank you for reaching out.</p>
-    <div class="rallies" aria-label="Rally lines">
-      <span>Trust is built, not bought.</span>
-      <span>People over PACs.</span>
-      <span>Built for Families. Built for WA-10.</span>
-    </div>
-  </div>
+  <span class="pill">Trust is built, not bought.</span>
+  <span class="pill">People over PACs.</span>
+  <span class="pill">Built for Families. Built for WA-10.</span>
 </div>
 
 <!-- NAV -->
-<nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom sticky-top" aria-label="Main">
+<nav class="navbar navbar-expand-lg bg-white border-bottom sticky-top" aria-label="Main">
   <div class="container">
     <a class="navbar-brand fw-bold" href="/index.html">Adam Neil Arafat for Congress - WA-10</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
@@ -217,121 +118,109 @@
         <li class="nav-item"><a class="nav-link" href="Bills/Bills.html"><i class="fa-solid fa-tree me-1 text-success" aria-hidden="true"></i>Evergreen Pact</a></li>
         <li class="nav-item"><a class="nav-link" href="/contrast.html">Record &amp; Contrast</a></li>
         <li class="nav-item"><a class="nav-link active" href="/contact.html" aria-current="page">Contact</a></li>
+        <li class="nav-item ms-lg-3"><a class="btn btn-primary" href="/contact.html">Join the Movement</a></li>
       </ul>
     </div>
   </div>
 </nav>
 
 <!-- HERO -->
-<section class="hero py-5">
+<section class="hero py-5 text-center">
   <div class="container">
     <div class="wrap p-4">
-      <h1 class="mb-1 h3">Contact the Campaign</h1>
-      <p class="mb-0">Questions, feedback, press, or getting involved. Your voice guides this effort.</p>
+      <h1 class="fw-bold mb-2">Contact the Campaign</h1>
+      <p class="lead mb-2">Ask a question, share feedback, or invite Adam to an event.</p>
+      <p class="mb-0 small">Trust is built, not bought. People over PACs. Built for Families. Built for WA-10.</p>
     </div>
   </div>
 </section>
 
-<main id="main" class="py-5">
-  <div class="container px-4">
-
-    <!-- Quick guidance -->
-    <div class="alert alert-primary border-0" role="note">
-      Prefer email? Click a button below and your email app will open with the right address and subject.
-    </div>
-
-    <div class="row g-4">
-      <!-- General -->
-      <div class="col-md-6">
-        <div class="contact-card h-100">
-          <div class="d-flex align-items-center mb-2">
-            <div class="icon"><i class="fa-regular fa-envelope"></i></div>
-            <h2 class="h5 m-0">General</h2>
-          </div>
-          <p class="mb-3">Questions, ideas, and media inquiries.</p>
-          <a id="generalEmailButton" class="btn btn-outline-primary"
-             href="mailto:info@arafatforcongress.org?subject=General%20question%20from%20{{name}}&body=Name:%20{{name}}%0AContact:%20{{contact}}%0ATopic:%20{{topic}}%0A%0AMessage:%0A{{message}}">
-             <i class="fa-regular fa-paper-plane me-1"></i>Email the Campaign
-          </a>
-        </div>
+<!-- PRIMARY CTAS -->
+<section class="py-4">
+  <div class="container">
+    <div class="row g-3 text-center">
+      <div class="col-md-4">
+        <a class="btn btn-outline-primary w-100" role="button" href="mailto:hello@arafatforcongress.org?subject=Question%20about%20WA-10&body=Name:%0D%0AZip:%0D%0ATopic:%0D%0AMessage:%0D%0A">Email the Campaign</a>
       </div>
-
-      <!-- Volunteer / Join the Team -->
-      <div class="col-md-6">
-        <div class="contact-card h-100">
-          <div class="d-flex align-items-center mb-2">
-            <div class="icon"><i class="fa-solid fa-users"></i></div>
-            <h2 class="h5 m-0">Join the Team Building WA-10</h2>
-          </div>
-          <p class="mb-3">Be part of the team fighting for working families in WA-10. Pick your level of involvement.</p>
-          <a id="volunteerEmailButton" class="btn btn-outline-primary"
-             href="mailto:volunteer@arafatforcongress.org?subject=Volunteer%20sign-up%20from%20{{name}}&body=Name:%20{{name}}%0AContact:%20{{contact}}%0AHow%20I%20can%20help:%0A{{message}}">
-             <i class="fa-regular fa-handshake me-1"></i>Join the Team
-          </a>
-        </div>
+      <div class="col-md-4">
+        <a class="btn btn-outline-primary w-100" role="button" href="mailto:hello@arafatforcongress.org?subject=Event%20invite:%20[City],%20[Date]&body=Name:%0D%0AOrganization:%0D%0AEvent%20details:%0D%0A">Invite Adam to Speak</a>
       </div>
-
-      <!-- Share Your Story -->
-      <div class="col-12">
-        <div class="story-box">
-          <div class="d-flex align-items-center mb-2">
-            <div class="icon" aria-hidden="true" style="width:42px;height:42px;border-radius:10px;background:#e6f0f8;color:#0d3b66;display:inline-flex;align-items:center;justify-content:center;margin-right:.5rem;">
-              <i class="fa-solid fa-comment-dots"></i>
-            </div>
-            <h2 class="h5 m-0">Share Your Story</h2>
-          </div>
-          <p class="mb-3">Tell me how healthcare, high costs, or corruption affect your family. I read every message.</p>
-
-          <!-- This is NOT a remote form. It just opens an email with your text. -->
-          <form id="contactForm" class="row g-3" onsubmit="return sendStoryEmail(event);" novalidate>
-            <div class="col-md-6">
-              <label for="name" class="form-label">Your name <span class="text-muted">(optional)</span></label>
-              <input type="text" class="form-control" id="name" autocomplete="name" aria-describedby="nameHelp" />
-              <div id="nameHelp" class="form-text">Optional</div>
-            </div>
-            <div class="col-md-6">
-              <label for="contact" class="form-label">Best contact <span class="text-muted">(optional)</span></label>
-              <input type="text" class="form-control" id="contact" placeholder="Email or phone" autocomplete="email" aria-describedby="contactHelp" />
-              <div id="contactHelp" class="form-text">Optional</div>
-            </div>
-            <div class="col-12">
-              <label for="topic" class="form-label">Topic</label>
-              <select id="topic" class="form-select" aria-describedby="topicHelp">
-                <option value="Healthcare">Healthcare</option>
-                <option value="Cost of Living">Cost of Living</option>
-                <option value="Corruption and Special Interests">Corruption and Special Interests</option>
-                <option value="Fair Taxation">Fair Taxation</option>
-                <option value="Corporate Accountability">Corporate Accountability</option>
-                <option value="Other">Other</option>
-              </select>
-              <div id="topicHelp" class="form-text">Choose a topic</div>
-            </div>
-            <div class="col-12">
-              <label for="message" class="form-label">Your story</label>
-              <textarea id="message" class="form-control" rows="5" placeholder="Write what you want me to know..." aria-describedby="messageHelp messageError"></textarea>
-              <div id="messageHelp" class="form-text">Minimum 15 characters.</div>
-              <div id="messageError" class="invalid-feedback"></div>
-            </div>
-            <div class="col-12 d-flex align-items-center gap-2">
-              <button type="submit" class="btn btn-primary">
-                <i class="fa-regular fa-paper-plane me-1"></i>Send via Email (opens your email app)
-              </button>
-              <small class="text-muted">Opens your email app. We don't store form data.</small>
-            </div>
-          </form>
-        </div>
+      <div class="col-md-4">
+        <a class="btn btn-primary w-100" role="button" href="mailto:volunteer@arafatforcongress.org?subject=Ready%20to%20join%20the%20team&body=Name:%0D%0AContact:%0D%0AHow%20I%20can%20help:%0D%0A">Join the Team</a>
       </div>
-
     </div>
+    <p class="mt-2 text-center small text-muted">Opens your email app. We don't store form data.</p>
+  </div>
+</section>
 
-    <!-- Donate CTA -->
-    <div class="mt-5 text-center">
-      <a class="btn btn-lg btn-donate" target="_blank" rel="noopener"
-         href="https://secure.actblue.com/donate/adam-arafat-1">
-         <i class="fa-solid fa-heart me-1"></i> Donate
-      </a>
+<main id="main">
+  <!-- SHARE YOUR STORY -->
+  <section class="py-5 border-top" id="story" style="scroll-margin-top:70px;">
+    <div class="container">
+      <h2 class="section-title mb-3">Share Your Story</h2>
+      <p class="mb-4">Tell me how healthcare costs, housing, or corruption hit home. Specifics help me fight smarter.</p>
+      <form id="storyForm" class="row g-3" novalidate>
+        <div class="col-md-6">
+          <label for="name" class="form-label">Name <span class="text-muted">(optional)</span></label>
+          <input type="text" class="form-control" id="name" autocomplete="name" aria-describedby="nameHelp" />
+          <div id="nameHelp" class="form-text">Optional</div>
+        </div>
+        <div class="col-md-6">
+          <label for="contact" class="form-label">Best contact <span class="text-muted">(optional)</span></label>
+          <input type="text" class="form-control" id="contact" placeholder="Email or phone" autocomplete="email" aria-describedby="contactHelp" />
+          <div id="contactHelp" class="form-text">Optional</div>
+        </div>
+        <div class="col-12">
+          <label for="topic" class="form-label">Topic</label>
+          <select id="topic" class="form-select" aria-describedby="topicHelp">
+            <option value="Healthcare">Healthcare</option>
+            <option value="Cost of Living">Cost of Living</option>
+            <option value="Corruption and Special Interests">Corruption and Special Interests</option>
+            <option value="Fair Taxation">Fair Taxation</option>
+            <option value="Corporate Accountability">Corporate Accountability</option>
+            <option value="Other">Other</option>
+          </select>
+          <div id="topicHelp" class="form-text">Choose a topic</div>
+        </div>
+        <div class="col-12">
+          <label for="message" class="form-label">Message</label>
+          <textarea id="message" class="form-control" rows="5" placeholder="Write what you want me to know..." aria-describedby="messageHelp messageError"></textarea>
+          <div id="messageHelp" class="form-text">Minimum 15 characters.</div>
+          <div id="messageError" class="invalid-feedback" aria-live="polite"></div>
+        </div>
+        <div class="col-12 d-flex align-items-center gap-2">
+          <button type="submit" id="sendEmail" class="btn btn-primary">
+            <i class="fa-regular fa-paper-plane me-1"></i>Send via Email
+          </button>
+          <small class="text-muted">Opens your email app. We don't store form data.</small>
+        </div>
+      </form>
     </div>
+  </section>
 
+  <!-- INVITE ADAM -->
+  <section class="py-5 border-top" id="invite" style="scroll-margin-top:70px;">
+    <div class="container text-center">
+      <h2 class="section-title mb-3">Invite Adam to speak</h2>
+      <p class="mb-4">Hosting a community event in WA-10? Let us know the details.</p>
+      <a class="btn btn-outline-primary" role="button" href="mailto:hello@arafatforcongress.org?subject=Event%20invite:%20[City],%20[Date]&body=Name:%0D%0AOrganization:%0D%0AEvent%20details:%0D%0A">Invite Adam to Speak</a>
+    </div>
+  </section>
+
+  <!-- JOIN THE TEAM -->
+  <section class="section-pad text-center" id="join" style="background:#0b2540; color:#fff; scroll-margin-top:70px;">
+    <div class="container">
+      <h2 class="fw-bold mb-3">Join the Team</h2>
+      <p class="mb-4">People over PACs. Built by neighbors.</p>
+      <a class="btn btn-light btn-lg text-primary" role="button" href="mailto:volunteer@arafatforcongress.org?subject=Ready%20to%20join%20the%20team&body=Name:%0D%0AContact:%0D%0AHow%20I%20can%20help:%0D%0A">Join the Team</a>
+    </div>
+  </section>
+
+  <!-- DONATE -->
+  <div class="mt-5 text-center">
+    <a class="btn btn-lg btn-donate" target="_blank" rel="noopener" href="https://secure.actblue.com/donate/adam-arafat-1">
+      <i class="fa-solid fa-heart me-1"></i> Donate
+    </a>
   </div>
 </main>
 
@@ -360,7 +249,29 @@
   </div>
 </footer>
 
-<script src="assets/js/contact.js"></script>
+<script>
+document.getElementById('storyForm').addEventListener('submit', function (e) {
+  e.preventDefault();
+  const topic = document.getElementById('topic').value || 'General';
+  const name = encodeURIComponent(document.getElementById('name').value || '');
+  const contact = encodeURIComponent(document.getElementById('contact').value || '');
+  const messageEl = document.getElementById('message');
+  const msg = messageEl.value.trim();
+  const errorEl = document.getElementById('messageError');
+  if (msg.length < 15) {
+    messageEl.classList.add('is-invalid');
+    errorEl.textContent = 'Please share at least 15 characters.';
+    return;
+  }
+  messageEl.classList.remove('is-invalid');
+  errorEl.textContent = '';
+  const subject = encodeURIComponent(`${topic} — message from WA-10`);
+  const body = `Name: ${name}%0D%0AContact: ${contact}%0D%0ATopic: ${topic}%0D%0A%0D%0A${encodeURIComponent(msg)}`;
+  window.location.href = `mailto:hello@arafatforcongress.org?subject=${subject}&body=${body}`;
+});
+document.getElementById('yr').textContent = new Date().getFullYear();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Align contact page nav and hero with rest of site
- Add desktop-row/mobile-stack CTA buttons for Email, Invite, and Join
- Simplify story form with topic-driven mailto handler and accessibility tweaks

## Testing
- `npm run prebuild` *(fails: Failed to refresh OpenSecrets data: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3978b026483239d5545ae6b6562b1