### PR TITLE
Restore tracking and contact metadata on key pages

### DIFF
--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
 <base href="/">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TSHYRZVZ97"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TSHYRZVZ97');
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>🌲 Evergreen Pact — Two Paths, Clear Steps | Adam Neil Arafat for Congress</title>
@@ -1415,7 +1423,7 @@
         <div class="p-4 h-100 rounded" style="background:#0b6e4f;color:#fff">
           <h2 class="h5 fw-bold mb-2">Join the fight</h2>
           <p class="mb-3">This campaign runs on people, not corporate political action committee money.</p>
-          <a href="../contact.html" class="btn btn-light fw-bold" target="_blank" rel="noopener noreferrer">I will volunteer</a>
+          <a href="/contact.html" class="btn btn-light fw-bold" target="_blank" rel="noopener noreferrer">I will volunteer</a>
         </div>
       </div>
       <div class="col-md-6">

--- a/contact.html
+++ b/contact.html
@@ -24,7 +24,7 @@
     "name": "Adam Neil Arafat for Congress",
     "url": "https://arafatforcongress.org",
     "contactPoint": [
-      {"@type":"ContactPoint","contactType":"general","email":"info@arafatforcongress.org"},
+      {"@type":"ContactPoint","contactType":"general","email":"hello@arafatforcongress.org"},
       {"@type":"ContactPoint","contactType":"volunteer","email":"volunteer@arafatforcongress.org"}
     ],
     "sameAs": [

--- a/contrast.html
+++ b/contrast.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
 <base href="/">
-  <!-- Analytics -->
+  <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TSHYRZVZ97"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){ dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config','G-TSHYRZVZ97');
+    gtag('config', 'G-TSHYRZVZ97');
   </script>
 
   <meta charset="UTF-8" />

--- a/issues.html
+++ b/issues.html
@@ -3,12 +3,13 @@
 <html lang="en">
 <head>
 <base href="/">
-  <!-- Analytics -->
+  <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TSHYRZVZ97"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date()); gtag('config', 'G-TSHYRZVZ97');
+    gtag('js', new Date());
+    gtag('config', 'G-TSHYRZVZ97');
   </script>
 
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- Reinstate Google Analytics snippet on Evergreen Pact, Issues, and Contrast pages
- Normalize contact schema to use hello@ for general inquiries
- Fix volunteer contact link on Evergreen Pact call-to-action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run prebuild` *(fails: Failed to refresh OpenSecrets data: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b399e2c3c8832398c7ffd9b19fb885