### PR TITLE
style: unify base styles and adjust contact CTAs

### DIFF
--- a/assets/css/compact.css
+++ b/assets/css/compact.css
@@ -9,14 +9,16 @@
 
 html{ scroll-behavior:smooth; }
 body{ line-height: 1.45; }
-
-:where(h1,h2,h3,h4){ margin: 0 0 .5em; line-height: 1.15; }
+:where(h1,h2,h3,h4){ margin: 0 0 .5em; }
+h1{ font-size:clamp(36px,5vw,42px); line-height:1.2; }
+h2{ font-size:clamp(28px,4vw,32px); line-height:1.25; }
+h3{ font-size:clamp(22px,3vw,24px); line-height:1.3; }
 :where(p,ul,ol){ margin: 0 0 .75em; }
 small, .eyebrow { opacity:.9; }
 
 /* Sections and containers */
-.section{ padding-block: clamp(16px, 2.5vw, 32px); }
-.container{ max-width: 1100px; padding-inline: clamp(12px,2vw,24px); margin-inline:auto; }
+section{ padding-block:56px; }
+.container{ max-width:1120px; margin:0 auto; padding-inline:20px; }
 
 /* Grids and gaps */
 .grid{ display:grid; gap: clamp(8px,2vw,16px); }
@@ -53,6 +55,19 @@ small, .eyebrow { opacity:.9; }
 /* Lists and buttons */
 .list-compact li{ margin-bottom: .4rem; }
 .button{ padding: 8px 12px; line-height: 1.1; }
+
+/* Buttons */
+.btn-primary{ background:#0a2a66; color:#fff; border-radius:10px; padding:.85rem 1.1rem; font-weight:700; display:inline-block; text-align:center; }
+.btn-primary:hover{ opacity:.9; }
+.btn-ghost{ background:transparent; border:1px solid #0a2a66; color:#0a2a66; border-radius:10px; padding:.85rem 1.1rem; font-weight:700; display:inline-block; text-align:center; }
+
+/* Cards */
+.card{ background:#fff; border:1px solid #e7e9ef; border-radius:14px; padding:20px; box-shadow:0 2px 10px rgba(0,0,0,.04); }
+
+/* Tables */
+.table{ width:100%; border-collapse:separate; border-spacing:0; }
+.table th, .table td{ padding:12px 14px; border-bottom:1px solid #e7e9ef; }
+.table thead th{ background:#f6f8fc; font-weight:700; }
 
 /* ===== Mobile left/right two-up helper ===== */
 .mobile-split{

--- a/contact.html
+++ b/contact.html
@@ -131,7 +131,7 @@
   <div class="container">
     <div class="wrap p-4">
       <h1 class="fw-bold mb-2">Contact the Campaign</h1>
-      <p class="lead mb-2">Ask a question, share feedback, or invite Adam to an event.</p>
+      <p class="lead mb-2">Grassroots and responsive. I read every message. Thank you for reaching out.</p>
       <p class="mb-0 small">Trust is built, not bought. People over PACs. Built for Families. Built for WA-10.</p>
     </div>
   </div>
@@ -142,16 +142,16 @@
   <div class="container">
     <div class="row g-3 text-center">
       <div class="col-md-4">
-        <a class="btn btn-outline-primary w-100" role="button" href="mailto:hello@arafatforcongress.org?subject=Question%20about%20WA-10&body=Name:%0D%0AZip:%0D%0ATopic:%0D%0AMessage:%0D%0A">Email the Campaign</a>
+        <a class="btn-primary w-100" role="button" href="mailto:info@arafatforcongress.org?subject=Volunteer%20-%20WA10">Join the Team</a>
       </div>
       <div class="col-md-4">
-        <a class="btn btn-outline-primary w-100" role="button" href="mailto:hello@arafatforcongress.org?subject=Event%20invite:%20[City],%20[Date]&body=Name:%0D%0AOrganization:%0D%0AEvent%20details:%0D%0A">Invite Adam to Speak</a>
+        <a class="btn-ghost w-100" role="button" href="mailto:press@arafatforcongress.org?subject=Media%20Inquiry">Press</a>
       </div>
       <div class="col-md-4">
-        <a class="btn btn-primary w-100" role="button" href="mailto:volunteer@arafatforcongress.org?subject=Ready%20to%20join%20the%20team&body=Name:%0D%0AContact:%0D%0AHow%20I%20can%20help:%0D%0A">Join the Team</a>
+        <a class="btn-ghost w-100" role="button" href="mailto:info@arafatforcongress.org?subject=General%20Question">Email the Campaign</a>
       </div>
     </div>
-    <p class="mt-2 text-center small text-muted">Opens your email app. We don't store form data.</p>
+    <p class="mt-2 text-center small text-muted">No data stored on this site. Your email client sends this message.</p>
   </div>
 </section>
 
@@ -182,7 +182,7 @@
             <option value="Corporate Accountability">Corporate Accountability</option>
             <option value="Other">Other</option>
           </select>
-          <div id="topicHelp" class="form-text">Choose a topic</div>
+          <div id="topicHelp" class="form-text">Pick the closest topic so we route it fast.</div>
         </div>
         <div class="col-12">
           <label for="message" class="form-label">Message</label>
@@ -194,7 +194,7 @@
           <button type="submit" id="sendEmail" class="btn btn-primary">
             <i class="fa-regular fa-paper-plane me-1"></i>Send via Email
           </button>
-          <small class="text-muted">Opens your email app. We don't store form data.</small>
+          <small class="text-muted">No data stored on this site. Your email client sends this message.</small>
         </div>
       </form>
     </div>

--- a/index.html
+++ b/index.html
@@ -24,10 +24,11 @@
     .lead { color:#1c2b3a; }
 
     /* Hero */
-    .hero { position:relative; min-height:60vh; }
-    .hero img.bg{position:absolute; inset:0; width:100%; height:100%; object-fit:cover; object-position:center; z-index:-2;}
-    .hero::before { content:""; position:absolute; inset:0; background:rgba(0,0,0,.45); z-index:-1; }
-    .hero > .container { position:relative; }
+    .hero { position:relative; min-height:60vh; color:#fff; }
+    .hero img.bg{position:absolute; inset:0; width:100%; height:100%; object-fit:cover; object-position:center; z-index:-1;}
+    .hero::before{ content:""; position:absolute; inset:0; background:linear-gradient(180deg, rgba(0,0,0,.55) 0%, rgba(0,0,0,.35) 35%, rgba(0,0,0,.25) 100%); }
+    .hero > *{ position:relative; z-index:1; }
+    .hero--light img{ filter:brightness(.75); }
     .hero h1 { font-size:2.5rem; }
     @media (min-width:768px){ .hero{min-height:70vh;} .hero h1{font-size:3rem;} }
 

--- a/issues.html
+++ b/issues.html
@@ -198,7 +198,7 @@
       <div class="divider"></div>
       <div class="row g-4 align-items-center">
         <div class="col-md-5">
-          <img class="issue-img" src="images/IMG_4349.jpeg" alt="Lowering the cost of living">
+          <img class="issue-img" src="images/IMG_4349.jpeg" alt="Illustration of family grocery budgeting">
         </div>
         <div class="col-md-7">
           <span class="badge badge-kicker rounded-pill px-3 py-2 mb-2 d-inline-block">Top Issue #1</span>
@@ -255,7 +255,7 @@
       <div class="divider"></div>
       <div class="row g-4 align-items-center">
         <div class="col-md-5">
-          <img class="issue-img" src="images/IMG_4339.jpeg" alt="Universal healthcare">
+          <img class="issue-img" src="images/IMG_4339.jpeg" alt="Illustration of doctor and patient discussing healthcare">
         </div>
         <div class="col-md-7">
           <span class="badge badge-kicker rounded-pill px-3 py-2 mb-2 d-inline-block">Top Issue #2</span>
@@ -280,7 +280,7 @@
       <div class="divider"></div>
       <div class="row g-4 align-items-center">
         <div class="col-md-5">
-          <img class="issue-img" src="images/IMG_4480.png" alt="End corruption and special interests">
+          <img class="issue-img" src="images/IMG_4480.png" alt="Graphic showing crossed-out money bags symbolizing corruption">
         </div>
         <div class="col-md-7">
           <span class="badge badge-kicker rounded-pill px-3 py-2 mb-2 d-inline-block">Top Issue #3</span>
@@ -307,7 +307,7 @@
       <div class="divider"></div>
       <div class="row g-4 align-items-center">
         <div class="col-md-5">
-          <img class="issue-img" src="images/IMG_4346.jpeg" alt="Tax fairness, corporate responsibility, and good jobs">
+          <img class="issue-img" src="images/IMG_4346.jpeg" alt="Illustration of workers building infrastructure for good jobs">
         </div>
         <div class="col-md-7">
           <h2 class="h4 section-title">Tax Fairness, CSR, and Good Jobs</h2>


### PR DESCRIPTION
## Summary
- standardize typography, section rhythm, and component styles
- add gradient overlay to home hero for better contrast
- streamline contact page copy, CTA order, and helper text
- provide descriptive alt text for issue illustrations

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b39eb649fc832386aa033078fa1f6b