### PR TITLE
Tighten Bills intro and layout spacing

### DIFF
--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -123,68 +123,17 @@
 </nav>
 
 <main id="main">
-<!-- HERO -->
-<header class="py-5 hero">
-  <div class="container text-center">
-    <h1 class="display-5 mb-2">🌲 The Evergreen Pact</h1>
-    <p class="lead mb-3">Two ladders for 2027. Each step helps working people without raising their taxes. Each step adds checks on executive power.</p>
-
-    <div class="d-flex justify-content-center gap-2 flex-wrap">
-      <a class="btn btn-outline-light btn-pill fw-bold ../Overview-btn btn-icon" href="Overview.html" target="_blank" rel="noopener noreferrer" aria-label="Download Evergreen Pact PDF">
-        <i class="fa-solid fa-file-pdf" aria-hidden="true"></i> Download PDF
-      </a>
-    </div>
-  </div>
+<header class="page-intro pact-intro">
+  <h1>The Evergreen Pact: What I’ll move in Congress, step by step</h1>
+  <p>This page shows the live plan. You’ll always see the current step first. Each card tells you two things in plain language:</p>
+  <ul>
+    <li>What you get at home</li>
+    <li>How it checks executive power</li>
+  </ul>
+  <p>Click Pass or Fail on a step to see what comes next and how it likely advances. No new taxes on working families. Ever.</p>
 </header>
-
-<!-- EXPLANATION -->
-<section class="container my-4">
-  <div class="row justify-content-center">
-    <div class="col-lg-10">
-      <h2 class="h4">What the Evergreen Pact is</h2>
-      <p class="mb-2"><strong>The Evergreen Pact is triage, then reform.</strong> We stop the bleeding now, then install hard blocks, transparency, and oversight to restore checks and balances to the full legal extent using every lawful tool, even the obscure ones. Every step lowers costs for working people without raising their taxes and reins in executive power.</p>
-    </div>
-  </div>
-</section>
-
-<!-- HOW TO USE -->
-<section class="container my-4">
-  <div class="row g-3">
-    <div class="col-lg-12">
-      <h2 class="h4">How to use this page</h2>
-      <p class="help-text mb-2">See the current step. Click “Pass” or “Fail” to reveal what’s next and update the odds.</p>
-      <p class="help-text mb-0">Each card shows:</p>
-      <ul class="help-text mb-0">
-        <li>For working people — the near-term benefit at home</li>
-        <li>Checks on executive power — how it restores balance</li>
-      </ul>
-    </div>
-  </div>
-</section>
 <section class="container my-4">
   <p class="last-updated">Pact last updated: August 30, 2025</p>
-</section>
-
-<section class="container my-4" id="pact-snapshot" aria-label="Pact quick snapshot">
-  <h2>Quick snapshot: Benefits | Legislative route | Timeline</h2>
-  <table class="tldr snapshot-table">
-    <thead><tr><th>Step</th><th>Local impact</th><th>Legislative route</th><th>Target date</th></tr></thead>
-    <tbody>
-      <tr>
-        <td><a href="#cost-of-living-savings">Energy Savings &amp; Lower Bills</a></td>
-        <td>Bigger rebates, community solar, simple local programs</td>
-        <td>Suspension or Energy title (FSGG/Approps)</td>
-        <td>Jan 2027</td>
-      </tr>
-      <tr>
-        <td><a href="#fair-food">Fair Food &amp; Grocery Competition</a></td>
-        <td>Stop junk fees and exclusionary deals at checkout</td>
-        <td>Suspension / Commerce title</td>
-        <td>Jan 2027</td>
-      </tr>
-      <!-- Continue for Jobs & Skills, Childcare, Permitting, 3% Mortgage, Tax Fairness, Corporate Responsibility, Clean Campaigns, Vote Justification, Universal Healthcare, Social Security -->
-    </tbody>
-  </table>
 </section>
 
 

--- a/styles.css
+++ b/styles.css
@@ -259,3 +259,93 @@ label{ font-weight:600; margin-bottom:.25rem; }
   a{ color:#9ec5ff; }
   .btn-primary{ background:#2b5da6; }
 }
+
+/* Global rhythm tighten */
+:root{
+  --space-xxs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-s: 0.75rem;
+  --space-m: 1rem;         /* used for most vertical spacing */
+  --space-l: 1.25rem;
+  --max-text: 68ch;        /* narrower for readability */
+}
+
+html{ scroll-behavior:smooth; }
+body{
+  line-height: 1.35;       /* down from ~1.5–1.6 */
+  letter-spacing: 0.01em;
+}
+
+/* Headings: collapse top/bottom margins */
+h1,h2,h3,h4{
+  margin-top: var(--space-m);
+  margin-bottom: var(--space-xs);
+}
+h1{ margin-top: var(--space-s); }
+p{ margin: var(--space-xs) 0; }
+ul,ol{ margin: var(--space-xs) 0 var(--space-s); padding-left: 1.1rem; }
+
+/* Constrain text width in the intro */
+.page-intro, .pact-intro{
+  max-width: var(--max-text);
+  margin-inline: auto;
+}
+
+/* Section blocks */
+.section, .tier, .path{
+  padding-top: var(--space-m);
+  padding-bottom: var(--space-m);
+}
+
+/* Cards */
+.card{
+  padding: var(--space-m);
+  gap: var(--space-s);
+  border-radius: 8px;
+}
+.card h4{ margin-bottom: var(--space-xs); }
+
+/* Meta rows (Vehicle/When/Status) */
+.meta{
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-xs) var(--space-m);
+  margin: var(--space-xs) 0 var(--space-s);
+}
+.meta > span{ white-space: nowrap; }
+
+/* Buttons and controls */
+.actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-s);
+}
+button,.btn,a.btn{
+  padding: 0.5rem 0.75rem;
+  line-height: 1.1;
+}
+
+/* Grids/lists of cards */
+.grid{
+  display:grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-m);
+}
+@media (min-width: 780px){
+  .grid{ grid-template-columns: 1fr 1fr; gap: var(--space-m); }
+}
+
+/* Tables that remain (if any) */
+table{ border-collapse: collapse; width:100%; }
+th,td{ padding: 0.5rem; }
+thead th{ position: sticky; top: 0; background: #fff; }
+tr + tr td{ border-top: 1px solid #eee; }
+
+/* Kill extra whitespace */
+hr{ margin: var(--space-m) 0; }
+.section + .section,
+.tier + .tier{ margin-top: var(--space-m); }
+
+/* Footer spacing near the page end */
+.footer-cta{ margin-top: var(--space-l); }


### PR DESCRIPTION
## Summary
- Replace Evergreen Pact page hero and intro with a concise overview explaining the step-by-step plan
- Remove redundant TL;DR table and update global CSS variables to tighten vertical rhythm and card spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3a6395bc4832391f4461003e4987c