### PR TITLE
refactor footer to shared include

### DIFF
--- a/Bills/Affordable Child and Dependent Care Bill (2027).html
+++ b/Bills/Affordable Child and Dependent Care Bill (2027).html
@@ -87,13 +87,6 @@ Comprehensive Care:
 Supports not only children but also elder care and disabled dependents.
 Deficit Neutral:
 Paid for by closing loopholes and redirecting subsidies, not by taxing working families.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -1392,13 +1392,8 @@
   </div>
 </section>
 
-<footer>
-  <div class="container text-center small">
-    <p class="mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="mb-0">&copy; 2027 Adam Neil Arafat. All Rights Reserved.</p>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
 <script>
   // ------- helpers

--- a/Bills/Bills2.html
+++ b/Bills/Bills2.html
@@ -167,12 +167,8 @@
   </div>
 </header>
 
-<footer class="mt-auto">
-  <div class="container text-center small py-3">
-    &copy; <span id="year"></span> Adam Neil Arafat for Congress — WA-10
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <!-- Bootstrap bundle -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 

--- a/Bills/Clean Campaigns and Elections Bill (2027).html
+++ b/Bills/Clean Campaigns and Elections Bill (2027).html
@@ -89,13 +89,6 @@ Enforceable Rules:
 A reformed FEC ensures violations are addressed swiftly, strengthening accountability.
 Deficit Neutral:
 Voucher program funded by closing political dark money loopholes and small redirections from enforcement penalties.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Congressional Vote Justification Bill (2027).html
+++ b/Bills/Congressional Vote Justification Bill (2027).html
@@ -157,13 +157,6 @@ Accountability without Overreach:
 Ethics referrals and sanctions create deterrence while preserving voting rights.
 Administrative Costs Only:
 Implemented via existing Congressional processes and publications.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Corporate Responsibility (CSR) Bill (2027).html
+++ b/Bills/Corporate Responsibility (CSR) Bill (2027).html
@@ -123,13 +123,6 @@ Transparent Markets:
 Public pay ratios, injury rates, and community metrics expose chronic violators.
 Efficient Enforcement:
 Uses existing IRS/DOL/OSHA/EPA/Government Accountability Office tools - formula-driven, not political.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Energy Savings and Lower Bills Bill (2027).html
+++ b/Bills/Energy Savings and Lower Bills Bill (2027).html
@@ -87,13 +87,6 @@ Economic Growth:
 Creates jobs in construction, manufacturing, and clean energy deployment.
 Deficit Neutral:
 Funded by ending fossil fuel giveaways, not taxing working families.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Fair Food and Grocery Competition Bill (2027).html
+++ b/Bills/Fair Food and Grocery Competition Bill (2027).html
@@ -92,13 +92,6 @@ Food Security:
 Protects SNAP households from unfair fees and strengthens regional food systems.
 Deficit Neutral:
 Paid for with enforcement fees and reallocations, not new taxes.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/First-Time Homebuyer 3% Mortgage Bill (2027).html
+++ b/Bills/First-Time Homebuyer 3% Mortgage Bill (2027).html
@@ -138,13 +138,6 @@ Feasibility
 Builds on FHA, VA, and USDA loan precedents.
 Uses existing federal housing infrastructure.
 Designed to be budget-neutral with no new taxes.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Good Jobs & Skills Bill (2027).html
+++ b/Bills/Good Jobs & Skills Bill (2027).html
@@ -96,13 +96,6 @@ Local Alignment:
 Training dollars map to real employer demand in each region.
 Sustainable Funding:
 Complements the Tax Fairness &amp; Relief Bill (2027) to cover costs without burdening working families.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/House majority, Senate minority.html
+++ b/Bills/House majority, Senate minority.html
@@ -318,9 +318,7 @@
 
 </main>
 
-<footer>
-  <p><strong>Next pages coming:</strong> House minority with Senate minority. House minority with Senate majority. House majority with Senate majority. Speaker toolkit. Senate floor leader toolkit.</p>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 </body>
 </html>

--- a/Bills/Housing Supply and Permitting Modernization Bill (2027).html
+++ b/Bills/Housing Supply and Permitting Modernization Bill (2027).html
@@ -100,13 +100,6 @@ Affordable First Homes:
 Brings monthly payments within reach for first-time buyers.
 Deficit Neutral:
 Pays for itself through reallocation and efficiency, not new taxes.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Impeachment Continuity and Accountability Bill (2027).html
+++ b/Bills/Impeachment Continuity and Accountability Bill (2027).html
@@ -211,13 +211,6 @@ Enforcement:
 Government Accountability Office/inspector general oversight with fast court remedies if rules are broken, plus daily fines and House litigation authority to compel compliance.
 Targeted:
 Life‑safety and disaster response protected by narrow carve‑outs.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Social Security Solvency Bill (2027).html
+++ b/Bills/Social Security Solvency Bill (2027).html
@@ -221,13 +221,6 @@ Transparency:
 Government Accountability Office audits and a public dashboard rebuild trust and accountability.
 Stronger Benefits:
 CPI‑E COLA and a minimum benefit floor keep seniors out of poverty.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Tax Fairness Bill (2027).html
+++ b/Bills/Tax Fairness Bill (2027).html
@@ -129,13 +129,6 @@ Working Families Protected:
 No new taxes for households under $400,000.
 Better Service:
 Modernized SSA systems and staffing reduce delays and errors.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/Universal Healthcare Bill (2027).html
+++ b/Bills/Universal Healthcare Bill (2027).html
@@ -94,13 +94,6 @@ Fair Funding:
 Wealthy households contribute more, middle- and working-class families pay no new taxes.
 Deficit Neutrality:
 Savings and targeted contributions make the program sustainable without adding to the deficit.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/committee-directives-gao-guards-2027.html
+++ b/Bills/committee-directives-gao-guards-2027.html
@@ -115,13 +115,8 @@ The Committee directs [Agency Name] to publish, no later than 30 days after enac
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/committee-report-directives-templates-2027.html
+++ b/Bills/committee-report-directives-templates-2027.html
@@ -115,13 +115,8 @@ Pre-Award Review. The Committee directs the inspector general of [Agency] to rev
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/communications-integrity-bill-2027.html
+++ b/Bills/communications-integrity-bill-2027.html
@@ -78,13 +78,6 @@ TITLE VII - JUDICIAL REVIEW
 Three-judge district court with direct appeal; 60-day target resolution; no automatic stay; deference to life-safety facts only, not legality.
 TITLE VIII - SUNSET &amp; SEVERABILITY
 Four-year sunset; severable; effective on enactment.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/continuity-integrity-expansion-bill-2027.html
+++ b/Bills/continuity-integrity-expansion-bill-2027.html
@@ -63,13 +63,6 @@ TITLE VII - PHASE-IN &amp; SUPPORT
 180-day phased compliance by cohorts (DoD/Treasury/Justice first; then HHS/DHS/Transportation; then the remainder). Office of Management and Budget technical assistance fund for small agencies’ IT adjustments.
 TITLE VIII - SUNSET &amp; SEVERABILITY
 Five-year sunset with report to Congress at 36 months; severable; effective on enactment.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/cra-disapproval-bill-style-2027.html
+++ b/Bills/cra-disapproval-bill-style-2027.html
@@ -56,13 +56,6 @@ That Congress disapproves the rule submitted by the [Agency], relating to “[Ru
 Notes
 Do not bundle multiple rules. File individually.
 Pair public comms with your dashboard narrative from Minibus-1 for clarity.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/cra-disapproval-templates-2027.html
+++ b/Bills/cra-disapproval-templates-2027.html
@@ -56,13 +56,6 @@ That Congress disapproves the rule submitted by the [Agency], relating to “[Ru
 Notes
 Do not bundle multiple rules. File individually.
 Pair public comms with your dashboard narrative from Minibus-1 for clarity.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/emergency-powers-spend-pilot-dod-bill-2027.html
+++ b/Bills/emergency-powers-spend-pilot-dod-bill-2027.html
@@ -71,13 +71,6 @@ TITLE V - JUDICIAL REVIEW
 Three-judge district court; direct appeal; rapid briefing; no automatic stay.
 TITLE VI - SUNSET &amp; REPORT
 Two-year pilot sunset. DoD + Office of Management and Budget report to Congress with metrics (response times, approvals, mission impacts) to inform the Continuity Integrity Expansion Bill.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/fallback-oversight-bill-2027.html
+++ b/Bills/fallback-oversight-bill-2027.html
@@ -169,13 +169,6 @@ Transparent processes that the public can see.
 Enforceable duties with quick court review.
 Back to All Bills
 Adam Neil Arafat for Congress - Washington’s Tenth District
-Paid for by Arafat for Congress. No corporate political action committee money.</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Paid for by Arafat for Congress. No corporate political action committee money.</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/fallback-oversight-toolkit-bill (2027).html
+++ b/Bills/fallback-oversight-toolkit-bill (2027).html
@@ -139,13 +139,6 @@ Directive completion:
 % milestones met; Government Accountability Office evaluation status.
 Enforcement:
 Days under fines; court orders issued; compliance achieved.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/fallback-oversight-toolkit.html
+++ b/Bills/fallback-oversight-toolkit.html
@@ -139,13 +139,6 @@ Directive completion:
 % milestones met; Government Accountability Office evaluation status.
 Enforcement:
 Days under fines; court orders issued; compliance achieved.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/holman-amendments-toolkit-2027.html
+++ b/Bills/holman-amendments-toolkit-2027.html
@@ -113,13 +113,8 @@ The position of [Title] is eliminated effective [Date]. The head of [Agency] sha
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/house-litigation-authorization-bill-style-2027.html
+++ b/Bills/house-litigation-authorization-bill-style-2027.html
@@ -52,13 +52,6 @@ Sec. 3. The Office of General Counsel shall report to the House on actions taken
 Usage notes
 Adopt this the same day you introduce Minibus-1 to maximize leverage.
 Coordinate with state AGs and NGOs for parallel APA suits where appropriate.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/house-litigation-authorization-template-2027.html
+++ b/Bills/house-litigation-authorization-template-2027.html
@@ -52,13 +52,6 @@ Sec. 3. The Office of General Counsel shall report to the House on actions taken
 Usage notes
 Adopt this the same day you introduce Minibus-1 to maximize leverage.
 Coordinate with state AGs and NGOs for parallel APA suits where appropriate.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/house-rules-guardrails-2027.html
+++ b/Bills/house-rules-guardrails-2027.html
@@ -115,13 +115,8 @@ Public Docket. The Clerk shall maintain a public docket listing each subpoena, n
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/minibus-implementation-safeguards-bill (2027).html
+++ b/Bills/minibus-implementation-safeguards-bill (2027).html
@@ -148,13 +148,6 @@ Fast resolution:
 Three-judge court with direct appeal keeps disputes from dragging out.
 Enforceable appropriations tools:
 Narrow riders and targeted Holman adjustments align spending with compliance.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/nea-wpr-resolution-bill-style-2027.html
+++ b/Bills/nea-wpr-resolution-bill-style-2027.html
@@ -58,13 +58,6 @@ SEC. 2. Removal from hostilities. The President shall remove United States Armed
 Usage notes
 Run National Emergencies Act and War Powers Resolution measures as standalones to keep privileges intact.
 Coordinate dates with the Minibus-1 covered-period definition to keep messaging tight.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/nea-wpr-resolution-templates-2027.html
+++ b/Bills/nea-wpr-resolution-templates-2027.html
@@ -58,13 +58,6 @@ SEC. 2. Removal from hostilities. The President shall remove United States Armed
 Usage notes
 Run National Emergencies Act and War Powers Resolution measures as standalones to keep privileges intact.
 Coordinate dates with the Minibus-1 covered-period definition to keep messaging tight.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/no-net-increase-guardrail.html
+++ b/Bills/no-net-increase-guardrail.html
@@ -111,13 +111,8 @@
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/resolution-of-inquiry-bill-style.html
+++ b/Bills/resolution-of-inquiry-bill-style.html
@@ -54,13 +54,6 @@ Scope and Format
 The materials shall be transmitted in electronic form to the Committee on ________ and shall include an index and a description sufficient to identify any redactions and the basis for each.
 Noncompliance Notice
 If the directed official fails to comply, the chair shall notify the House and place on the calendar a resolution finding noncompliance and recommending appropriate enforcement action.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li><strong>Clear</strong> standards and faster resolution.</li><li><strong>Lower</strong> waste and better outcomes.</li><li><strong>Transparent</strong> processes that the public can see.</li><li><strong>Enforceable</strong> duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/resolution-of-inquiry-template.html
+++ b/Bills/resolution-of-inquiry-template.html
@@ -54,13 +54,6 @@ Scope and Format
 The materials shall be transmitted in electronic form to the Committee on ________ and shall include an index and a description sufficient to identify any redactions and the basis for each.
 Noncompliance Notice
 If the directed official fails to comply, the chair shall notify the House and place on the calendar a resolution finding noncompliance and recommending appropriate enforcement action.
-Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><footer class="py-4 border-top bg-white">
-<div class="container small">
-<div class="row g-3 align-items-center">
-<div class="col-12">
-<strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-<span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-</div>
-</div>
-</div>
-</footer><script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>
+Back to All Bills</pre></div></div></div><div class="accordion-item tight-card"><h2 class="accordion-header" id="roiHeading"><button aria-controls="roiCollapse" aria-expanded="false" class="accordion-button collapsed collapse-toggle" data-bs-target="#roiCollapse" data-bs-toggle="collapse" type="button"><i class="fa-solid fa-chart-line"></i>Results and Return on Investment</button></h2><div aria-labelledby="roiHeading" class="accordion-collapse collapse" data-bs-parent="#billAccordion" id="roiCollapse"><div class="accordion-body"><ul class="mb-0"><li>Clear standards and faster resolution.</li><li>Lower waste and better outcomes.</li><li>Transparent processes that the public can see.</li><li>Enforceable duties with quick court review.</li></ul></div></div></div></div><div class="text-center my-3"><a class="btn btn-outline-primary" href="/Bills/Bills.html"><i aria-hidden="true" class="fa-solid fa-arrow-left me-2"></i>Back to All Bills</a></div></div><div id="footer"></div>
+<script src="footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script></body>

--- a/Bills/senate-rule-xiv-companion.html
+++ b/Bills/senate-rule-xiv-companion.html
@@ -113,13 +113,8 @@ I object to further proceedings to which the reading of the bill may be referred
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/subpoena-daily-fines.html
+++ b/Bills/subpoena-daily-fines.html
@@ -123,13 +123,8 @@
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/surgical-riders-holman-templates-2027.html
+++ b/Bills/surgical-riders-holman-templates-2027.html
@@ -113,13 +113,8 @@ For purposes of this section, the term "funds" includes money, supplies, staff t
   </div>
 </main>
 
-<footer class="py-4 border-top bg-white">
-  <div class="container small">
-    <strong>Adam Neil Arafat for Congress — Washington’s Tenth District</strong><br/>
-    <span class="text-muted">Paid for by Arafat for Congress. No corporate political action committee money.</span>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Bills/test.html
+++ b/Bills/test.html
@@ -160,13 +160,8 @@
   <div class="alert alert-info small">This demo file focuses on the header signature blocks and API wiring. Plug it into your full Bills page to replace the top section.</div>
 </section>
 
-<footer>
-  <div class="container text-center small">
-    <p class="mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="mb-0">&copy; 2025 Adam Neil Arafat. All Rights Reserved.</p>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
   // ===== Replace with your deployed Apps Script Web App URL (must end with /exec)

--- a/Overview.html
+++ b/Overview.html
@@ -139,8 +139,7 @@
   </div>
 </main>
 
-<footer class="py-3 text-center small" style="background:#0d3b66;color:#fff">
-  &copy; 2027 Adam Neil Arafat. All Rights Reserved.
-</footer>
+<div id="footer"></div>
+<script src="footer.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -341,42 +341,8 @@
   </div>
 </section>
 
-<footer class="footer-legal py-4 border-top text-center">
-  <div class="container">
-    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-0">Not authorized by any other candidate or candidate's committee.</p>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('yr').textContent = new Date().getFullYear();
-
-  // Mailto composer for "Share Your Story" - no external form or service.
-  function sendStoryEmail(e){
-    e.preventDefault();
-    const name = document.getElementById('storyName').value.trim();
-    const contact = document.getElementById('storyContact').value.trim();
-    const topic = document.getElementById('storyCategory').value;
-    const message = document.getElementById('storyMessage').value.trim();
-
-    const to = 'info@arafatforcongress.org';
-    const subject = encodeURIComponent(`Story: ${topic}${name ? ' - ' + name : ''}`);
-    const bodyLines = [];
-
-    if (name) bodyLines.push(`Name: ${name}`);
-    if (contact) bodyLines.push(`Best contact: ${contact}`);
-    bodyLines.push(`Topic: ${topic}`);
-    bodyLines.push('');
-    bodyLines.push('Story:');
-    bodyLines.push(message || '(Your story here)');
-
-    const body = encodeURIComponent(bodyLines.join('\n'));
-    const href = `mailto:${to}?subject=${subject}&body=${body}`;
-    window.location.href = href;
-    return false;
-  }
-</script>
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/contrast.html
+++ b/contrast.html
@@ -359,20 +359,13 @@
 
 </main>
 
-<footer class="py-4 bg-white border-top text-center">
-  <div class="container">
-    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-3">Not authorized by any other candidate or candidate's committee.</p>
-  </div>
-</footer>
-
+<div id="footer"></div>
+<script src="footer.js"></script>
 <!-- Sticky donate (mobile) -->
 <a class="btn btn-donate sticky-donate" href="https://secure.actblue.com/donate/adam-arafat-1" target="_blank" rel="noopener" aria-label="Quick donate">
   <i class="fa-solid fa-heart"></i>
 </a>
 
-<script>document.getElementById('yr').textContent = new Date().getFullYear();</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/digging-into-the-issues.html
+++ b/digging-into-the-issues.html
@@ -365,17 +365,8 @@
   </div>
 </section>
 
-<footer class="py-4 bg-white border-top text-center">
-  <div class="container">
-    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-3">Not authorized by any other candidate’s committee.</p>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('yr').textContent = new Date().getFullYear();
-</script>
+<div id="footer"></div>
+<script src="footer.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,7 @@
+<footer class="py-4 bg-white border-top text-center">
+  <div class="container">
+    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
+    <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
+    <p class="small text-muted mb-3">Not authorized by any other candidate or candidate's committee.</p>
+  </div>
+</footer>

--- a/footer.js
+++ b/footer.js
@@ -1,0 +1,12 @@
+(function(){
+  const placeholder = document.getElementById('footer');
+  if(!placeholder) return;
+  fetch('footer.html')
+    .then(resp => resp.text())
+    .then(html => {
+      placeholder.innerHTML = html;
+      const yr = placeholder.querySelector('#yr');
+      if(yr) yr.textContent = new Date().getFullYear();
+    })
+    .catch(err => console.error('Footer load failed', err));
+})();

--- a/index.html
+++ b/index.html
@@ -229,15 +229,9 @@
 
 </main>
 
-<footer class="py-4 bg-white border-top text-center">
-  <div class="container">
-    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-1">Paid for by Adam Neil Arafat for Congress</p>
-    <p class="small text-muted mb-3">Not authorized by any other candidate or candidate's committee</p>
-  </div>
-</footer>
+<div id="footer"></div>
+<script src="footer.js"></script>
 
-<script>document.getElementById('yr').textContent = new Date().getFullYear();</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/test1.html
+++ b/test1.html
@@ -130,84 +130,8 @@
   </div>
 </main>
 
-<footer class="footer-legal py-4 border-top text-center">
-  <div class="container">
-    <p class="small text-muted mb-1">© <span id="yr"></span> Adam Neil Arafat for Congress</p>
-  </div>
-</footer>
-
-<script>
-  document.getElementById('yr').textContent = new Date().getFullYear();
-
-  // === CONFIG ===
-  const WEBAPP_URL = "https://script.google.com/macros/s/AKfycbyHPZAWXfICEXJI6ipXLXF5cAh5gQe3U_616AV2y_XROk0vjex_fYG9MmL9aI9TMcgA/exec";
-
-  // UTM helpers
-  function getUTM(name) { const p = new URLSearchParams(window.location.search); return p.get(name) || ''; }
-
-  // mailto fallback
-  function composeMailto(payload){
-    const to = 'info@arafatforcongress.org';
-    const subject = encodeURIComponent(`Story: ${payload.topic}${payload.name ? ' - ' + payload.name : ''}`);
-    const body = encodeURIComponent(
-      `Name: ${payload.name}\nContact: ${payload.email}\nTopic: ${payload.topic}\n\nStory:\n${payload.message}`
-    );
-    return `mailto:${to}?subject=${subject}&body=${body}`;
-  }
-
-  async function submitContact(e){
-    e.preventDefault();
-
-    const name = document.getElementById('storyName').value.trim();
-    const email = document.getElementById('storyContact').value.trim();
-    const phone = '';
-    const message = document.getElementById('storyMessage').value.trim();
-
-    if (!email && !phone && !message) {
-      alert('Please provide at least your email, phone, or a message.');
-      return false;
-    }
-
-    const payload = {
-      source: 'website',
-      type: 'contact',
-      name,
-      email,
-      phone,
-      zip: '',
-      topic: document.getElementById('storyCategory').value,
-      message,
-      utm_source: getUTM('utm_source'),
-      utm_medium: getUTM('utm_medium'),
-      utm_campaign: getUTM('utm_campaign'),
-      userAgent: navigator.userAgent
-    };
-
-    try {
-      const form = new URLSearchParams();
-      Object.entries(payload).forEach(([k, v]) => form.append(k, v));
-      const res = await fetch(WEBAPP_URL, { method: "POST", body: form });
-      const text = await res.text();
-      let data;
-      try { data = JSON.parse(text); } catch { data = null; }
-      if (data && data.ok) {
-        alert("Thanks for sharing your story! We received it.");
-        document.getElementById('contactForm').reset();
-        return false;
-      }
-      if (data && data.error) {
-        alert(`Error: ${data.error}`);
-        return false;
-      }
-      // If response isn't JSON or missing expected fields, treat as failure
-      throw new Error("Invalid response");
-    } catch (err) {
-      console.warn("POST failed; falling back to mailto.", err);
-      window.location.href = composeMailto(payload);
-      return false;
-    }
-  }
-</script>
+<div id="footer"></div>
+<script src="footer.js"></script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- centralize repeated footer HTML into standalone `footer.html`
- dynamically load footer in pages with new `footer.js`
- update pages to reference shared include and drop address text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aa9cb40883239e4014c8760b133c