### PR TITLE
Reduce homepage section spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
 <main id="main">
 
   <!-- WHY IT MATTERS -->
-  <section id="why-it-matters" class="section-pad">
+  <section id="why-it-matters" class="section-pad pb-4">
     <div class="container">
       <h1 class="mb-3">Power People. Not PACs.</h1>
       <ul class="mb-0">
@@ -174,7 +174,7 @@
   </section>
 
   <!-- MEET ADAM -->
-  <section id="meet-adam" class="section-pad section-alt">
+  <section id="meet-adam" class="section-pad section-alt py-4">
     <div class="container">
       <h2 class="section-title mb-4">Meet Adam</h2>
       <div class="row align-items-center g-4">
@@ -198,7 +198,7 @@
   </section>
 
   <!-- Evergreen Pact + Contrast cards -->
-  <section class="section-pad">
+  <section class="section-pad pt-4">
     <div class="container">
       <div class="row g-4">
         <div class="col-md-6">


### PR DESCRIPTION
## Summary
- Tighten padding after "Why it Matters" so the next section starts closer.
- Balance spacing around the "Meet Adam" section to reduce gaps before and after.
- Trim top padding before Evergreen Pact cards for a more compact layout.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aab6fc188323bc0e7d33def5f22f