### PR TITLE
Update contrast page with marker-delimited comparison content

### DIFF
--- a/contrast.html
+++ b/contrast.html
@@ -174,186 +174,81 @@
 
 <main>
 
-  <!-- WHY IT MATTERS -->
-  <section class="py-5 border-bottom">
-    <div class="container">
-      <h2 class="section-title mb-3">Why this choice matters</h2>
-      <p class="lead mb-2">
-        Do not settle for polished politicians. WA-10 needs a fighter ready with day one bills to lower costs, expand healthcare, and clean up corruption.
-        I have spent months researching and drafting <a href="Bills/Bills.html">blueprints to action</a>. I am ready to take them to Congress and go to work for you.
-      </p>
+  <!-- START: RIGHT_CHOICE_TO_SOURCES -->
+<!-- Only real choice (callout) -->
+<section class="section" id="only-real-choice">
+  <div class="container">
+    <h2 class="h4 fw-bold mb-2">Why I’m the Right Choice</h2>
+    <div class="card card-lite good p-3">
+      <p class="mb-0 fw-semibold">I refuse AIPAC and corporate PAC money, no strings. I work for WA-10, not lobbyists. I deliver kitchen-table bills that cut costs and expand care, and I publish every vote, meeting, and dollar. I’m the only candidate in WA-10 you can trust.</p>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- FUNDING SNAPSHOT -->
-  <section class="py-5" style="background:var(--soft);">
-    <div class="container">
-      <h3 class="h5 section-title mb-3">Funding snapshot</h3>
-      <p class="mb-3">
-        When more than 4 of 5 individual donor dollars come from outside WA-10, those are not our neighbors shaping priorities. It is national networks and lobby groups.
-        That is why I refuse corporate PAC money and why I have proposed a <a href="Bills/Clean Campaigns and Elections Bill (2027).html">Clean Campaigns Bill</a> to end pay to play.
-      </p>
-      <div class="row g-3">
-        <div class="col-md-6">
-          <div class="fund-card h-100">
-            <h3>$2.05M</h3>
-            <div class="pct">82% out of district</div>
-            <div class="small text-muted mt-1">2023–2024 cycle. Geography from itemized individual donors only. See sources.</div>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="fund-card h-100">
-            <h3>44%</h3>
-            <div class="pct">from PACs</div>
-            <div class="small text-muted mt-1">Share of campaign committee receipts in 2023–2024. See sources.</div>
-          </div>
-        </div>
+<!-- Side by side (top) -->
+<section class="section bg-light" id="side-by-side">
+  <div class="container">
+    <h2 class="h3 fw-bold mb-3">Side by side: who fights for you</h2>
+    <div class="grid-2">
+      <div class="card card-lite good p-3">
+        <div class="contrast-badge">Adam</div>
+        <div class="contrast-row"><svg class="icon me-2 check" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M20.285 6.709l-11 11-5.5-5.5 1.414-1.414 4.086 4.086 9.586-9.586z"/></svg> Refuses AIPAC and corporate PAC cash.</div>
+        <div class="contrast-row"><svg class="icon me-2 check" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M20.285 6.709l-11 11-5.5-5.5 1.414-1.414 4.086 4.086 9.586-9.586z"/></svg> Drafts kitchen-table bills you feel in your budget.</div>
+        <div class="contrast-row"><svg class="icon me-2 check" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M20.285 6.709l-11 11-5.5-5.5 1.414-1.414 4.086 4.086 9.586-9.586z"/></svg> Fights for universal coverage you can actually use.</div>
+        <div class="contrast-row"><svg class="icon me-2 check" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M20.285 6.709l-11 11-5.5-5.5 1.414-1.414 4.086 4.086 9.586-9.586z"/></svg> Protects free speech and civil rights.</div>
+        <div class="contrast-row"><svg class="icon me-2 check" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M20.285 6.709l-11 11-5.5-5.5 1.414-1.414 4.086 4.086 9.586-9.586z"/></svg> Reports votes and meetings publicly.</div>
       </div>
-      <div class="alert alert-secondary small mt-3 mb-0" role="note">
-        AIPAC is listed as a top contributor in 2023–2024. This speaks to incentives and alignment. See sources.
+      <div class="card card-lite warn p-3">
+        <div class="contrast-badge">Opponent <span class="flag-badge">Red flags</span></div>
+        <div class="contrast-row"><svg class="icon me-2 x" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M5 3h2v18H5z"/><path d="M7 4h12l-3 3 3 3H7z"/></svg> Voted for the Antisemitism Awareness Act (H.R. 6090), a bill civil-liberties groups warned would chill First Amendment speech, aligning with AIPAC’s agenda <a class="ms-1" href="https://clerk.house.gov/Votes/2024172" target="_blank" rel="noopener">(roll call)</a>.</div>
+        <div class="contrast-row"><svg class="icon me-2 x" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M5 3h2v18H5z"/><path d="M7 4h12l-3 3 3 3H7z"/></svg> Accepts money from the Pro-Israel industry and other PACs <a class="ms-1" href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/industries?cid=N00046320&cycle=2024&type=I" target="_blank" rel="noopener">(source)</a>.</div>
+        <div class="contrast-row"><svg class="icon me-2 x" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M5 3h2v18H5z"/><path d="M7 4h12l-3 3 3 3H7z"/></svg> Spends time on symbolic bills that stall <a class="ms-1" href="https://www.congress.gov/bill/118th-congress/house-bill/6090" target="_blank" rel="noopener">(example)</a>.</div>
+        <div class="contrast-row"><svg class="icon me-2 x" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M5 3h2v18H5z"/><path d="M7 4h12l-3 3 3 3H7z"/></svg> Backs a limited public option, not universal care <a class="ms-1" href="https://stricklandforwashington.com/priorities/universal-health-care/" target="_blank" rel="noopener">(source)</a>.</div>
+        <div class="contrast-row"><svg class="icon me-2 x" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M5 3h2v18H5z"/><path d="M7 4h12l-3 3 3 3H7z"/></svg> Opposed Seattle’s 2018 head tax as Chamber CEO <a class="ms-1" href="https://www.knkx.org/business/2018-03-16/business-head-tax-back-on-the-table-for-seattle-city-council" target="_blank" rel="noopener">(audio)</a>.</div>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- COMPARISON TABLE -->
-  <section class="compare-wrap py-5">
-    <div class="container">
-      <h3 class="section-title mb-3 text-center">Side by side</h3>
-      <div class="table-responsive">
-        <table class="table compare align-middle">
-          <thead>
-            <tr>
-              <th style="width:48%">Adam Neil Arafat</th>
-              <th style="width:52%">Status quo pattern</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><span class="ok">✔</span> Fight for hard wins. Write, negotiate, and move bills that matter for working families.</td>
-              <td><span class="no">✘</span> Focus on low conflict and ceremonial items. Plays it safe instead of taking on big fights.</td>
-            </tr>
-            <tr>
-              <td><span class="ok">✔</span> Fight for Medicare for All with automatic enrollment and lower drug costs.</td>
-              <td><span class="no">✘</span> Favors a limited public option over universal healthcare. This keeps the private insurance market in charge.</td>
-            </tr>
-            <tr>
-              <td><span class="ok">✔</span> Deliver lower costs and more housing with accountability for bad actors.</td>
-              <td><span class="no">✘</span> Opposed Seattle's 2018 head tax that funded homelessness and affordable housing work.</td>
-            </tr>
-            <tr>
-              <td><span class="ok">✔</span> Refuse corporate PAC money. Hold open town halls. Put people first.</td>
-              <td><span class="no">✘</span> About 82% of individual donor dollars from outside WA-10 and 44% of receipts from PACs. Tied to national donor networks.</td>
-            </tr>
-            <tr>
-              <td><span class="ok">✔</span> Defend the First Amendment while standing up to lobby pressure.</td>
-              <td><span class="no">✘</span> Voted Yea on the Antisemitism Awareness Act of 2023 (H.R. 6090) that civil liberties groups warn chills protected speech.</td>
-            </tr>
-          </tbody>
-        </table>
+<!-- Funding Snapshot -->
+<section class="section">
+  <div class="container">
+    <h2 class="h3 fw-bold mb-3" id="funding-snapshot">Funding snapshot</h2>
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-kicker">Out of district (itemized individuals)</div>
+        <div class="stat-number">85%</div>
+        <div class="stat-amount">$1,820,123</div>
+        <div class="stat-note">Based on your compiled totals for 2023–2024. Percentages are computed from the amounts shown and rounded to whole numbers. For itemized-only shares from OpenSecrets Geography, percentages may differ. <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/geography?cid=N00046320&cycle=2024" target="_blank" rel="noopener">See itemized breakdown</a>.</div>
       </div>
-      <p class="fineprint mt-2 mb-0">Figures use rounded percentages consistent with public tracker categories.</p>
-      <p class="fineprint mb-0">Sources are public. They show patterns and incentives. They do not allege illegality.</p>
-    </div>
-  </section>
-
-  <!-- EXPANDED RECEIPTS -->
-  <section class="py-5">
-    <div class="container">
-      <h3 class="section-title mb-3">🔦 Expanded Receipts on Strickland</h3>
-
-      <h5>Corporate and PAC money</h5>
-      <p>She takes AIPAC and corporate PAC cash. Those networks spend to protect the status quo. I refuse corporate PAC money. My votes will never be bought.</p>
-
-      <h5>Free speech and the First Amendment</h5>
-      <p>She voted for the Antisemitism Awareness Act, a bill civil liberties groups warned would silence constitutionally protected speech and protest. That is a vote against the First Amendment. I will always defend your right to speak freely.</p>
-
-      <h5>Healthcare</h5>
-      <p>She favors a limited public option, not universal coverage. A public option just adds another plan to the insurance market. It leaves families stuck with high premiums, co-pays, and medical debt. I will co-sponsor a roadmap to Medicare for All so every family is covered.</p>
-
-      <h5>Housing and cost of living</h5>
-      <p>While housing costs skyrocket, she has delivered piecemeal grants and ribbon cuttings. No bold supply expansion and no permitting reform. I will fight to cut red tape, build faster, and offer 3 percent mortgages for first time buyers.</p>
-
-      <h5>Military vs. families</h5>
-      <p>She votes for bloated Pentagon budgets while failing to deliver relief at the grocery store or pharmacy. I will cut waste and invest in working families instead of defense contractors.</p>
-
-      <div class="border rounded p-3 mt-3">
-        <strong>Key contrast soundbite</strong>
-        <p class="mb-0">She took AIPAC money and voted against free speech. She backs a public option that preserves the insurance industry instead of fighting for universal care. She funds the Pentagon but leaves families drowning in bills. I will deliver real healthcare, lower costs, and integrity in office.</p>
+      <div class="stat-card">
+        <div class="stat-kicker">In district (itemized individuals)</div>
+        <div class="stat-number">15%</div>
+        <div class="stat-amount">$320,123</div>
+        <div class="stat-note">Based on your compiled totals for 2023–2024. Percentages are computed from the amounts shown and rounded to whole numbers. For itemized-only shares from OpenSecrets Geography, percentages may differ. <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/geography?cid=N00046320&cycle=2024" target="_blank" rel="noopener">See itemized breakdown</a>.</div>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- EXPLANATIONS / ROLL-UP -->
-  <section class="py-4">
-    <div class="container">
-      <h3 class="h6 section-title mb-3">Notes and methods</h3>
-      <div class="accordion" id="notes">
-        <div class="accordion-item">
-          <h2 class="accordion-header" id="n1h">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#n1" aria-expanded="false" aria-controls="n1">
-              Funding context
-            </button>
-          </h2>
-          <div id="n1" class="accordion-collapse collapse" aria-labelledby="n1h" data-bs-parent="#notes">
-            <div class="accordion-body small">
-              Percentages use OpenSecrets categories. Out of district is calculated only from itemized individual donors. PAC share uses FEC summary. See linked OpenSecrets pages for methodology notes and update timestamps.
-            </div>
-          </div>
-        </div>
-
-        <div class="accordion-item mt-2">
-          <h2 class="accordion-header" id="n2h">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#n2" aria-expanded="false" aria-controls="n2">
-              AIPAC shorthand
-            </button>
-          </h2>
-          <div id="n2" class="accordion-collapse collapse" aria-labelledby="n2h" data-bs-parent="#notes">
-            <div class="accordion-body small">
-              "AIPAC" refers to contributions from AIPAC and aligned donors as categorized by OpenSecrets. Mention here signals alignment and incentives. It does not allege illegality or foreign money.
-            </div>
-          </div>
-        </div>
-
-        <div class="accordion-item mt-2">
-          <h2 class="accordion-header" id="n3h">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#n3" aria-expanded="false" aria-controls="n3">
-              Bipartisan scores vs leadership
-            </button>
-          </h2>
-          <div id="n3" class="accordion-collapse collapse" aria-labelledby="n3h" data-bs-parent="#notes">
-            <div class="accordion-body small">
-              Bipartisan index scores reward cross party cosponsorship and routine votes. Leadership on hard fights shows up in initiating, organizing, and moving contested policy that lowers costs and expands rights.
-            </div>
-          </div>
-        </div>
-
-        <div class="accordion-item mt-2">
-          <h2 class="accordion-header" id="n4h">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#n4" aria-expanded="false" aria-controls="n4">
-              Sources
-            </button>
-          </h2>
-          <div id="n4" class="accordion-collapse collapse" aria-labelledby="n4h" data-bs-parent="#notes">
-            <div class="accordion-body small">
-              <ul class="mb-2">
-                <li>OpenSecrets — Source of Funds 2023–2024: PAC share ~44% — <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/summary?cid=N00046320" target="_blank" rel="noopener">opensecrets.org</a></li>
-                <li>OpenSecrets — Geography 2023–2024: Out of district ~82% of itemized individual giving — <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/geography?cid=N00046320&cycle=2024" target="_blank" rel="noopener">opensecrets.org</a></li>
-                <li>OpenSecrets — Top contributors: AIPAC listed among top contributors in 2023–2024 — <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/summary?cid=N00046320" target="_blank" rel="noopener">opensecrets.org</a></li>
-                <li>House Roll Call on H.R. 6090 Antisemitism Awareness Act 2024-05-01: Strickland Yea — <a href="https://www.congress.gov/votes/house/118-2/172" target="_blank" rel="noopener">congress.gov</a> and <a href="https://clerk.house.gov/Votes/2024172" target="_blank" rel="noopener">clerk.house.gov</a></li>
-                <li>Healthcare stance — public option: campaign site and materials — <a href="https://stricklandforwashington.com/priorities/universal-health-care/" target="_blank" rel="noopener">stricklandforwashington.com</a>, <a href="https://stricklandforwashington.com/wp-content/uploads/2020/07/Strickland-Healthcare-Plan.pdf" target="_blank" rel="noopener">healthcare plan PDF</a>, reporting: <a href="https://www.cascadepbs.org/politics/2020/08/what-separates-strickland-and-doglio-was-10th-congressional-district/" target="_blank" rel="noopener">Cascade PBS</a></li>
-                <li>Opposed Seattle head tax as Chamber president in 2018 — <a href="https://www.knkx.org/business/2018-03-16/business-head-tax-back-on-the-table-for-seattle-city-council" target="_blank" rel="noopener">KNKX</a>, <a href="https://www.klgates.com/Congressional-Meet-and-Greet-with-Marilyn-Strickland-WA-10-D-11-20-2020" target="_blank" rel="noopener">K&L Gates bio</a></li>
-                <li>Lugar Center Bipartisan Index context — <a href="https://www.thelugarcenter.org/ourwork-Bipartisan-Index.html" target="_blank" rel="noopener">thelugacenter.org</a></li>
-              </ul>
-              <div class="small text-muted">Update windows: OpenSecrets summary last updated 2025-08-18 for funds and source of funds. Geography page reflects itemized individual data as of 2025-02-06. Always check timestamps on linked pages.</div>
-            </div>
-          </div>
-        </div>
-
-      </div>
+<!-- Clear Claims, Clear Records -->
+<section class="section" id="key-claims">
+  <div class="container">
+    <h2 class="h4 fw-bold mb-3">Clear Claims, Clear Records</h2>
+    <div class="card card-lite p-3">
+      <ul class="source-list small mb-0">
+        <li><strong>I’m the only candidate in WA-10 with no AIPAC or corporate PAC influence.</strong><br><span class="text-muted">Support:</span> OpenSecrets shows the opponent’s PAC money is dominated by <em>business PACs</em> (~76% of PAC receipts, 2023–2024). <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/summary?cid=N00046320" target="_blank" rel="noopener">OpenSecrets summary</a>.</li>
+        <li><strong>My funding comes from right here—not from out-of-district donors pushing corporate agendas.</strong><br><span class="text-muted">Support:</span> Your compiled itemized totals (2020–2024): <strong>$1.82M</strong> out-of-district (~85%) vs <strong>$320K</strong> in-district (~15%). See the <a href="#funding-snapshot">Funding snapshot</a> above; see also OpenSecrets <a href="https://www.opensecrets.org/members-of-congress/marilyn-strickland/geography?cid=N00046320&cycle=2024" target="_blank" rel="noopener">Geography</a> for itemized-only shares.</li>
+        <li><strong>She voted to censor student voices. I defend yours.</strong><br><span class="text-muted">Support:</span> Voted Yea on the Antisemitism Awareness Act (H.R. 6090), which civil-liberties groups warned would chill speech on campus. <a href="https://clerk.house.gov/Votes/2024172" target="_blank" rel="noopener">House roll call</a>, <a href="https://www.congress.gov/bill/118th-congress/house-bill/6090" target="_blank" rel="noopener">Congress.gov</a>.</li>
+        <li><strong>She’s busy with flashy bills. I’m delivering tangible savings on your grocery bill and healthcare.</strong><br><span class="text-muted">Support:</span> You are prioritizing kitchen-table legislation; contrast with her record of symbolic or low-impact bills. <a href="https://www.congress.gov/member/marilyn-strickland" target="_blank" rel="noopener">Member page</a>.</li>
+        <li><strong>Every vote, meeting, and expense I’ve had is online, judged by you almost instantly.</strong><br><span class="text-muted">Support:</span> Public commitment to publish votes, meetings, and spending for radical transparency.</li>
+        <li><strong>When Seattle tried to make big employers pay a little more, she said no. I’d have said yes for working families.</strong><br><span class="text-muted">Support:</span> As Chamber CEO, she opposed the 2018 Seattle head tax. <a href="https://www.knkx.org/business/2018-03-16/business-head-tax-back-on-the-table-for-seattle-city-council" target="_blank" rel="noopener">KNKX report + audio</a>.</li>
+      </ul>
     </div>
-  </section>
-
-  <!-- CALL TO ACTION -->
+  </div>
+</section>
+<!-- END: RIGHT_CHOICE_TO_SOURCES -->
+<!-- CALL TO ACTION -->
   <section class="py-5 text-center">
     <div class="container">
       <h3 class="h5 section-title mb-2">This seat belongs to WA-10</h3>


### PR DESCRIPTION
## Summary
- replace old contrast blocks with new "Right Choice" content
- add unique start/end markers for future updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cde251b0832391a553528a519026