### PR TITLE
Add social sharing assets, metadata and sitemap

### DIFF
--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -4,21 +4,19 @@
 <base href="/">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>🌲 Evergreen Pact — Two Paths, Clear Steps | Adam Neil Arafat for Congress</title>
-  <meta name="description" content="Two ladders for 2027. Path A if Democrats win the House and Senate. Path B if Democrats win the House only. Click Pass or Fail to reveal the next branch and updated chances." />
-  <meta name="theme-color" content="#0d3b66" />
-
-  <!-- Open Graph / Twitter -->
-  <meta property="og:title" content="Evergreen Pact — Two Paths, Clear Steps" />
-  <meta property="og:description" content="Two ladders for 2027. Each step helps working people without raising their taxes and restores checks and balances to the full legal extent." />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="/assets/evergreen-tree.png" />
-  <meta property="og:url" content="https://arafatforcongress.org/Bills/Bills.html" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Evergreen Pact — Two Paths, Clear Steps" />
-  <meta name="twitter:description" content="Two ladders for 2027. Each step helps working people without raising their taxes and restores checks and balances." />
-  <meta name="twitter:image" content="/assets/evergreen-tree.png" />
-  <link rel="canonical" href="https://arafatforcongress.org/Bills/Bills.html" />
+    <title>The Evergreen Pact – Step by Step</title>
+  <meta name="description" content="Win early. Build momentum. A step-by-step plan that helps now and sets up the hard fights next.">
+  <link rel="canonical" href="https://arafatforcongress.org/Bills/Bills.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Arafat for Congress – WA-10">
+  <meta property="og:title" content="The Evergreen Pact">
+  <meta property="og:description" content="Win early. Build momentum.">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-pact.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/Bills/Bills.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Evergreen Pact">
+  <meta name="twitter:description" content="Win early. Build momentum.">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-pact.svg">
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet"/>
@@ -123,6 +121,13 @@
     </div>
   </div>
 </header>
+
+<div class="share" data-url="https://arafatforcongress.org/Bills/Bills.html">
+  <a href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2FBills%2FBills.html" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
+  <a href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2FBills%2FBills.html" target="_blank" rel="noopener" aria-label="Share on Bluesky">Bluesky</a>
+  <a href="https://twitter.com/intent/tweet?text=Lower%20costs.%20Real%20care.%20Clean%20government.%20https%3A%2F%2Farafatforcongress.org%2FBills%2FBills.html" target="_blank" rel="noopener" aria-label="Share on X">X</a>
+  <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2FBills%2FBills.html" target="_blank" rel="noopener" aria-label="Share on Facebook">Facebook</a>
+</div>
 
 <!-- EXPLANATION -->
 <section class="container my-4">

--- a/about.html
+++ b/about.html
@@ -12,19 +12,19 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Meet Adam – Arafat for Congress</title>
-  <meta name="theme-color" content="#0d3b66" />
-  <meta name="description" content="Meet Adam Neil Arafat. Dad, husband, Army veteran, and public servant focused on lowering costs, healthcare, and clean government." />
-  <meta property="og:title" content="Meet Adam – Arafat for Congress" />
-  <meta property="og:description" content="Meet Adam Neil Arafat. Dad, husband, Army veteran, and public servant focused on lowering costs, healthcare, and clean government." />
-  <meta property="og:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <meta property="og:url" content="https://arafatforcongress.org/about.html" />
-  <meta property="og:type" content="website" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Meet Adam – Arafat for Congress" />
-  <meta name="twitter:description" content="Meet Adam Neil Arafat. Dad, husband, Army veteran, and public servant focused on lowering costs, healthcare, and clean government." />
-  <meta name="twitter:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <link rel="canonical" href="https://arafatforcongress.org/about.html" />
+    <title>Meet Adam – Adam Arafat</title>
+  <meta name="description" content="Meet Adam Arafat: dad, veteran, and public servant focused on lower costs, real care, and clean government.">
+  <link rel="canonical" href="https://arafatforcongress.org/about.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Arafat for Congress – WA-10">
+  <meta property="og:title" content="Meet Adam – Adam Arafat">
+  <meta property="og:description" content="Dad, veteran, public servant. Trust is built, not bought.">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/about.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Meet Adam – Adam Arafat">
+  <meta name="twitter:description" content="Dad, veteran, public servant. Trust is built, not bought.">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -284,6 +284,12 @@
       </ul>
     </div>
   </section>
+  <div class="share" data-url="https://arafatforcongress.org/about.html">
+    <a href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
+    <a href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on Bluesky">Bluesky</a>
+    <a href="https://twitter.com/intent/tweet?text=Lower%20costs.%20Real%20care.%20Clean%20government.%20https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on X">X</a>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on Facebook">Facebook</a>
+  </div>
 </main>
 
 <!-- FOOTER (Social strip + legal) -->

--- a/assets/share/og-contrast.svg
+++ b/assets/share/og-contrast.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <defs>
+    <style>
+      .bg{fill:#0f1f2c}.accent{fill:#db3a34}.light{fill:#fff}.muted{fill:#cfe3f1}
+      .kicker{font:700 24px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+      .title{font:800 62px/1.1 Inter,system-ui}
+      .body{font:600 34px/1.3 Inter,system-ui}
+      .tag{font:600 22px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="630"/>
+  <rect class="accent" width="1200" height="14"/>
+  <text class="kicker light" x="60" y="110">Record and contrast</text>
+  <text class="title light" x="60" y="200">I work for WA-10, not lobbyists.</text>
+  <text class="body muted" x="60" y="280">I refuse corporate PAC money. My votes and budgets are public.</text>
+  <text class="body muted" x="60" y="330">Judge me on receipts, not slogans.</text>
+  <text class="tag light" x="60" y="570">See the receipts • arafatforcongress.org/contrast.html</text>
+</svg>

--- a/assets/share/og-home.svg
+++ b/assets/share/og-home.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <defs>
+    <style>
+      .bg{fill:#0b2337}.accent{fill:#26a269}.light{fill:#fff}.muted{fill:#cfe3f1}
+      .title{font:800 70px/1.1 Inter,system-ui}
+      .kicker{font:700 24px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+      .body{font:600 36px/1.25 Inter,system-ui}
+      .tag{font:600 22px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="630"/>
+  <rect class="accent" width="1200" height="14"/>
+  <text class="kicker light" x="60" y="110">Arafat for Congress • WA-10</text>
+  <text class="title light" x="60" y="210">ADAM ARAFAT</text>
+  <text class="body muted" x="60" y="280">Trust is built, not bought.</text>
+  <text class="body muted" x="60" y="330">No corporate PAC money. Accountable to WA-10.</text>
+  <text class="tag light" x="60" y="570">ArafatForCongress.org</text>
+</svg>

--- a/assets/share/og-issues.svg
+++ b/assets/share/og-issues.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <defs>
+    <style>
+      .bg{fill:#13293d}.accent{fill:#1b6fd1}.light{fill:#fff}.muted{fill:#cfe3f1}
+      .kicker{font:700 24px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+      .title{font:800 64px/1.1 Inter,system-ui}
+      .list{font:600 36px/1.3 Inter,system-ui}
+      .tag{font:600 22px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="630"/>
+  <rect class="accent" width="1200" height="14"/>
+  <text class="kicker light" x="60" y="110">Where I stand</text>
+  <text class="title light" x="60" y="200">The priorities</text>
+  <text class="list muted" x="60" y="280">1) Lower costs for families</text>
+  <text class="list muted" x="60" y="330">2) Healthcare you can use</text>
+  <text class="list muted" x="60" y="380">3) End corruption and special interests</text>
+  <text class="tag light" x="60" y="570">Read more • arafatforcongress.org/issues.html</text>
+</svg>

--- a/assets/share/og-pact.svg
+++ b/assets/share/og-pact.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <defs>
+    <style>
+      .bg{fill:#0b2337}.accent{fill:#26a269}.light{fill:#fff}.muted{fill:#cfe3f1}
+      .kicker{font:700 24px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+      .title{font:800 64px/1.1 Inter,system-ui}
+      .body{font:600 34px/1.3 Inter,system-ui}
+      .tag{font:600 22px/1 Inter,system-ui;letter-spacing:.08em;text-transform:uppercase}
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="630"/>
+  <rect class="accent" width="1200" height="14"/>
+  <text class="kicker light" x="60" y="110">The Evergreen Pact</text>
+  <text class="title light" x="60" y="200">Win early. Build momentum.</text>
+  <text class="body muted" x="60" y="280">A step-by-step plan to pass what helps now</text>
+  <text class="body muted" x="60" y="330">and line up the hard fights next.</text>
+  <text class="tag light" x="60" y="570">See the steps • arafatforcongress.org/Bills/Bills.html</text>
+</svg>

--- a/contact.html
+++ b/contact.html
@@ -12,19 +12,19 @@
 
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Contact - Adam Neil Arafat for Congress</title>
-    <meta name="theme-color" content="#0d3b66" />
-    <meta name="description" content="Reach the campaign. Join the team building WA-10. Share your story. We read every message." />
-    <meta property="og:title" content="Contact - Adam Neil Arafat for Congress" />
-    <meta property="og:description" content="Reach the campaign. Join the team building WA-10. Share your story. We read every message." />
-    <meta property="og:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-    <meta property="og:url" content="https://arafatforcongress.org/contact.html" />
-    <meta property="og:type" content="website" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Contact - Adam Neil Arafat for Congress" />
-    <meta name="twitter:description" content="Reach the campaign. Join the team building WA-10. Share your story. We read every message." />
-    <meta name="twitter:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-    <link rel="canonical" href="https://arafatforcongress.org/contact.html" />
+        <title>Contact – Adam Arafat for Congress</title>
+    <meta name="description" content="Reach the campaign. Join the team building WA-10. Share your story. We read every message.">
+    <link rel="canonical" href="https://arafatforcongress.org/contact.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Arafat for Congress – WA-10">
+    <meta property="og:title" content="Contact – Adam Arafat for Congress">
+    <meta property="og:description" content="Reach the campaign. Join the team building WA-10. We read every message.">
+    <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
+    <meta property="og:url" content="https://arafatforcongress.org/contact.html">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Contact – Adam Arafat for Congress">
+    <meta name="twitter:description" content="Reach the campaign. Join the team building WA-10. We read every message.">
+    <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -332,6 +332,13 @@
          href="https://secure.actblue.com/donate/adam-arafat-1">
          <i class="fa-solid fa-heart me-1"></i> Donate
       </a>
+    </div>
+
+    <div class="share" data-url="https://arafatforcongress.org/contact.html">
+      <a href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
+      <a href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on Bluesky">Bluesky</a>
+      <a href="https://twitter.com/intent/tweet?text=Lower%20costs.%20Real%20care.%20Clean%20government.%20https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on X">X</a>
+      <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on Facebook">Facebook</a>
     </div>
 
   </div>

--- a/contrast.html
+++ b/contrast.html
@@ -13,19 +13,19 @@
 
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Strickland is not delivering. I will. - Adam Neil Arafat for Congress</title>
-  <meta name="description" content="Clear, sourced differences in WA-10. Funding, performance, and priorities side by side." />
-  <meta name="theme-color" content="#0d3b66" />
-  <meta property="og:title" content="Strickland is not delivering. I will." />
-  <meta property="og:description" content="Funding and performance contrast for WA-10." />
-  <meta property="og:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <meta property="og:url" content="https://arafatforcongress.org/contrast.html" />
-  <meta property="og:type" content="website" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Strickland is not delivering. I will." />
-  <meta name="twitter:description" content="Funding and performance contrast for WA-10." />
-  <meta name="twitter:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <link rel="canonical" href="https://arafatforcongress.org/contrast.html" />
+    <title>Record and Contrast – Adam Arafat</title>
+  <meta name="description" content="I refuse corporate PAC money. My votes and budgets are public. Judge me on receipts.">
+  <link rel="canonical" href="https://arafatforcongress.org/contrast.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Arafat for Congress – WA-10">
+  <meta property="og:title" content="Record and Contrast">
+  <meta property="og:description" content="No corporate PAC money. Receipts over rhetoric.">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-contrast.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/contrast.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Record and Contrast">
+  <meta name="twitter:description" content="No corporate PAC money. Receipts over rhetoric.">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-contrast.svg">
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
@@ -349,6 +349,13 @@
       </a>
     </div>
   </section>
+
+  <div class="share" data-url="https://arafatforcongress.org/contrast.html">
+    <a href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
+    <a href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on Bluesky">Bluesky</a>
+    <a href="https://twitter.com/intent/tweet?text=Lower%20costs.%20Real%20care.%20Clean%20government.%20https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on X">X</a>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on Facebook">Facebook</a>
+  </div>
 
 </main>
 

--- a/index.html
+++ b/index.html
@@ -4,19 +4,19 @@
   <base href="/">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Adam Neil Arafat for Congress - Washington's 10th District</title>
-  <meta name="theme-color" content="#0d3b66" />
-  <meta name="description" content="A people-powered campaign for WA-10: Medicare for All, lower costs, more housing, and honest government without corporate PAC money." />
-  <meta property="og:title" content="Adam Neil Arafat for Congress - Washington's 10th District" />
-  <meta property="og:description" content="A people-powered campaign for WA-10: Medicare for All, lower costs, more housing, and honest government without corporate PAC money." />
-  <meta property="og:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <meta property="og:url" content="https://arafatforcongress.org/index.html" />
-  <meta property="og:type" content="website" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Adam Neil Arafat for Congress - Washington's 10th District" />
-  <meta name="twitter:description" content="A people-powered campaign for WA-10: Medicare for All, lower costs, more housing, and honest government without corporate PAC money." />
-  <meta name="twitter:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <link rel="canonical" href="https://arafatforcongress.org/index.html" />
+    <title>Adam Arafat for Congress – WA-10</title>
+  <meta name="description" content="Lower costs, healthcare you can use, and clean government. No corporate PAC money.">
+  <link rel="canonical" href="https://arafatforcongress.org/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Arafat for Congress – WA-10">
+  <meta property="og:title" content="Adam Arafat for Congress – WA-10">
+  <meta property="og:description" content="Lower costs, healthcare you can use, and clean government.">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Adam Arafat for Congress – WA-10">
+  <meta name="twitter:description" content="Lower costs, healthcare you can use, and clean government.">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
@@ -237,6 +237,13 @@
       </a>
     </div>
   </section>
+
+  <div class="share" data-url="https://arafatforcongress.org/">
+    <a href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
+    <a href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on Bluesky">Bluesky</a>
+    <a href="https://twitter.com/intent/tweet?text=Lower%20costs.%20Real%20care.%20Clean%20government.%20https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on X">X</a>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on Facebook">Facebook</a>
+  </div>
 
 </main>
 

--- a/issues.html
+++ b/issues.html
@@ -4,18 +4,19 @@
   <base href="/">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Issues | Arafat for Congress</title>
-  <meta name="description" content="Adam Arafat's clear commitments on costs, healthcare, corruption, housing, schools, jobs, safety, climate, and rights." />
-  <meta property="og:title" content="Issues | Arafat for Congress" />
-  <meta property="og:description" content="Adam Arafat's clear commitments on costs, healthcare, corruption, housing, schools, jobs, safety, climate, and rights." />
-  <meta property="og:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <meta property="og:url" content="https://arafatforcongress.org/issues.html" />
-  <meta property="og:type" content="website" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Issues | Arafat for Congress" />
-  <meta name="twitter:description" content="Adam Arafat's clear commitments on costs, healthcare, corruption, housing, schools, jobs, safety, climate, and rights." />
-  <meta name="twitter:image" content="/images/4cc2b9ce-fb10-491b-99bf-bcb1d1134346.jpeg" />
-  <link rel="canonical" href="https://arafatforcongress.org/issues.html" />
+    <title>Where I Stand – Adam Arafat</title>
+  <meta name="description" content="The priorities: lower costs, healthcare you can use, end corruption and special interests.">
+  <link rel="canonical" href="https://arafatforcongress.org/issues.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Arafat for Congress – WA-10">
+  <meta property="og:title" content="Where I Stand">
+  <meta property="og:description" content="Lower costs. Healthcare you can use. End corruption.">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-issues.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/issues.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Where I Stand">
+  <meta name="twitter:description" content="Lower costs. Healthcare you can use. End corruption.">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-issues.svg">
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
@@ -323,6 +324,12 @@
         <a class="btn" style="background:#0b2d33" href="/volunteer.html">Volunteer</a>
       </div>
     </div>
+  <div class="share" data-url="https://arafatforcongress.org/issues.html">
+    <a href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
+    <a href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on Bluesky">Bluesky</a>
+    <a href="https://twitter.com/intent/tweet?text=Lower%20costs.%20Real%20care.%20Clean%20government.%20https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on X">X</a>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on Facebook">Facebook</a>
+  </div>
 </main>
 
 <div id="footer"></div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://arafatforcongress.org/index.html</loc></url>
+  <url><loc>https://arafatforcongress.org/</loc></url>
   <url><loc>https://arafatforcongress.org/issues.html</loc></url>
   <url><loc>https://arafatforcongress.org/contrast.html</loc></url>
   <url><loc>https://arafatforcongress.org/about.html</loc></url>


### PR DESCRIPTION
## Summary
- Add poster-style Open Graph SVG assets for home, issues, contrast and Evergreen Pact pages
- Supply Open Graph and Twitter metadata to main site pages and install share-link blocks
- Provide robots.txt and sitemap.xml for basic SEO
- Switch sitemap entry to canonical root URL
- Remove placeholder PNGs to keep repository text-only; meta tags now reference SVG versions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c63c26808323ba2c6653bf2dc3c6