### PR TITLE
feat: add social share links to header pills

### DIFF
--- a/about.html
+++ b/about.html
@@ -145,21 +145,12 @@
 <!-- SOCIAL MEDIA BAR -->
 <section class="social-top py-2">
   <div class="container d-flex flex-wrap justify-content-center gap-2">
-    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Follow Adam on Bluesky">
-      <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
-      <span>Bluesky</span>
-    </a>
-      <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa8?_t=ZT-8yve7Bzjrd0&_r=1" target="_blank" rel="noopener" aria-label="Follow Adam on TikTok">
-        <i class="fa-brands fa-tiktok"></i> <span>TikTok</span>
-      </a>
-      <a class="social-pill" href="https://x.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="Follow Adam on X">
-        <i class="fa-brands fa-x-twitter"></i> <span>X</span>
-      </a>
-      <a class="social-pill" href="https://www.facebook.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="Follow Adam on Facebook">
-        <i class="fa-brands fa-facebook"></i> <span>Facebook</span>
-      </a>
-    </div>
-  </section>
+    <a class="social-pill" href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on Reddit"><i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span></a>
+    <a class="social-pill" href="https://bsky.app/intent/compose?text=Meet%20Adam%20%E2%80%93%20Adam%20Arafat%20https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on Bluesky"><svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg> <span>Bluesky</span></a>
+    <a class="social-pill" href="https://twitter.com/intent/tweet?text=Meet%20Adam%20%E2%80%93%20Adam%20Arafat%20https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on X"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
+    <a class="social-pill" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fabout.html" target="_blank" rel="noopener" aria-label="Share on Facebook"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
+  </div>
+</section>
 
 <!-- HEADER BREAK -->
 <div class="header-break">

--- a/contact.html
+++ b/contact.html
@@ -170,21 +170,12 @@
 <!-- SOCIAL MEDIA BAR -->
 <section class="social-top py-2">
   <div class="container d-flex flex-wrap justify-content-center gap-2">
-    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Follow Adam on Bluesky">
-      <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
-      <span>Bluesky</span>
-    </a>
-      <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa8?_t=ZT-8yve7Bzjrd0&_r=1" target="_blank" rel="noopener" aria-label="Follow Adam on TikTok">
-        <i class="fa-brands fa-tiktok"></i> <span>TikTok</span>
-      </a>
-      <a class="social-pill" href="https://x.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="Follow Adam on X">
-        <i class="fa-brands fa-x-twitter"></i> <span>X</span>
-      </a>
-      <a class="social-pill" href="https://www.facebook.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="Follow Adam on Facebook">
-        <i class="fa-brands fa-facebook"></i> <span>Facebook</span>
-      </a>
-    </div>
-  </section>
+    <a class="social-pill" href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on Reddit"><i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span></a>
+    <a class="social-pill" href="https://bsky.app/intent/compose?text=Contact%20%E2%80%93%20Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on Bluesky"><svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg> <span>Bluesky</span></a>
+    <a class="social-pill" href="https://twitter.com/intent/tweet?text=Contact%20%E2%80%93%20Adam%20Arafat%20for%20Congress%20https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on X"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
+    <a class="social-pill" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fcontact.html" target="_blank" rel="noopener" aria-label="Share on Facebook"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
+  </div>
+</section>
 
 <!-- HEADER BREAK (wrapped in container for better line length) -->
 <div class="header-break">

--- a/contrast.html
+++ b/contrast.html
@@ -241,21 +241,12 @@
 <!-- SOCIAL BAR -->
 <section class="social-top py-2">
   <div class="container d-flex flex-wrap justify-content-center gap-2">
-    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Bluesky">
-      <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
-      <span>Bluesky</span>
-    </a>
-      <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa8" target="_blank" rel="noopener" aria-label="TikTok">
-        <i class="fa-brands fa-tiktok"></i><span>TikTok</span>
-      </a>
-      <a class="social-pill" href="https://x.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="X">
-        <i class="fa-brands fa-x-twitter"></i><span>X</span>
-      </a>
-      <a class="social-pill" href="https://www.facebook.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="Facebook">
-        <i class="fa-brands fa-facebook"></i><span>Facebook</span>
-      </a>
-    </div>
-  </section>
+    <a class="social-pill" href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on Reddit"><i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span></a>
+    <a class="social-pill" href="https://bsky.app/intent/compose?text=Record%20and%20Contrast%20%E2%80%93%20Adam%20Arafat%20https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on Bluesky"><svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg> <span>Bluesky</span></a>
+    <a class="social-pill" href="https://twitter.com/intent/tweet?text=Record%20and%20Contrast%20%E2%80%93%20Adam%20Arafat%20https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on X"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
+    <a class="social-pill" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fcontrast.html" target="_blank" rel="noopener" aria-label="Share on Facebook"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
+  </div>
+</section>
 
 <!-- HEADER PILLS -->
 <div class="header-break">

--- a/index.html
+++ b/index.html
@@ -145,13 +145,10 @@
 <!-- SOCIAL BAR -->
 <section class="social-top py-2">
   <div class="container d-flex flex-wrap justify-content-center gap-2">
-    <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Bluesky">
-      <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
-      <span>Bluesky</span>
-    </a>
-    <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa8?_t=ZT-8yve7Bzjrd0&_r=1" target="_blank" rel="noopener"><i class="fa-brands fa-tiktok"></i> <span>TikTok</span></a>
-    <a class="social-pill" href="https://x.com/AdamArafatWA" target="_blank" rel="noopener"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
-    <a class="social-pill" href="https://www.facebook.com/AdamArafatWA" target="_blank" rel="noopener"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
+    <a class="social-pill" href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on Reddit"><i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span></a>
+    <a class="social-pill" href="https://bsky.app/intent/compose?text=Adam%20Arafat%20for%20Congress%20%E2%80%93%20WA-10%20https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on Bluesky"><svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg> <span>Bluesky</span></a>
+    <a class="social-pill" href="https://twitter.com/intent/tweet?text=Adam%20Arafat%20for%20Congress%20%E2%80%93%20WA-10%20https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on X"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
+    <a class="social-pill" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2F" target="_blank" rel="noopener" aria-label="Share on Facebook"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
   </div>
 </section>
 

--- a/issues.html
+++ b/issues.html
@@ -127,15 +127,12 @@
 <!-- SOCIAL BAR -->
 <section class="social-top py-2">
   <div class="container d-flex flex-wrap justify-content-center gap-2">
-      <a class="social-pill" href="https://bsky.app/profile/adamneila.bsky.social" target="_blank" rel="noopener" aria-label="Blue sky">
-        <svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg>
-        <span>Bluesky</span>
-      </a>
-      <a class="social-pill" href="https://www.tiktok.com/@adam.arafat.for.wa8?_t=ZT-8yve7Bzjrd0&_r=1" target="_blank" rel="noopener"><i class="fa-brands fa-tiktok"></i> <span>TikTok</span></a>
-      <a class="social-pill" href="https://x.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="X"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
-      <a class="social-pill" href="https://www.facebook.com/AdamArafatWA" target="_blank" rel="noopener" aria-label="Facebook"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
-    </div>
-  </section>
+    <a class="social-pill" href="https://www.reddit.com/submit?url=https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on Reddit"><i class="fa-brands fa-reddit-alien"></i> <span>Reddit</span></a>
+    <a class="social-pill" href="https://bsky.app/intent/compose?text=Where%20I%20Stand%20%E2%80%93%20Adam%20Arafat%20https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on Bluesky"><svg class="bsky-icon" viewBox="0 0 600 600" aria-hidden="true"><path fill="#fff" d="M300 352c-48-68-151-157-214-193-23-13-53-21-77-21 0 104 29 170 95 236 49 49 120 81 196 81s147-32 196-81c66-66 95-132 95-236-24 0-54 8-77 21-63 36-166 125-214 193z"/></svg> <span>Bluesky</span></a>
+    <a class="social-pill" href="https://twitter.com/intent/tweet?text=Where%20I%20Stand%20%E2%80%93%20Adam%20Arafat%20https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on X"><i class="fa-brands fa-x-twitter"></i> <span>X</span></a>
+    <a class="social-pill" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Farafatforcongress.org%2Fissues.html" target="_blank" rel="noopener" aria-label="Share on Facebook"><i class="fa-brands fa-facebook"></i> <span>Facebook</span></a>
+  </div>
+</section>
 
 <!-- HEADER PILLS -->
 <div class="header-break">


### PR DESCRIPTION
## Summary
- redirect header social pills to share links (Reddit, Bluesky, X, Facebook)
- keep footer area unchanged as requested

## Testing
- `npx -y htmlhint index.html contact.html issues.html contrast.html about.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d7363ea48323b23d6458a19c6e01