### PR TITLE
Revise contrast page funding note with grassroots message

### DIFF
--- a/contrast.html
+++ b/contrast.html
@@ -315,7 +315,7 @@
   <section class="section">
   <div class="container">
     <h2 class="h3 fw-bold mb-3" id="funding-snapshot">Strickland’s funding snapshot</h2>
-    <figure aria-describedby="funding-note">
+    <figure>
       <div class="stats-grid">
         <div class="stat-card">
           <i class="fa-solid fa-flag text-danger mb-2" aria-hidden="true"></i>
@@ -329,8 +329,10 @@
           <div class="stat-number">15%</div>
           <div class="stat-amount">$320,123</div>
         </div>
+        <div class="stat-card" id="funding-note">
+          <i class="fa-solid fa-circle-check text-success me-2" aria-hidden="true"></i>My Record: I don’t take PAC or special interest money. My campaign is powered by small donations from right here in WA-10. 💪
+        </div>
       </div>
-      <figcaption id="funding-note"><i class="fa-solid fa-flag text-success me-2" aria-hidden="true"></i>My record: only small in-district donations.</figcaption>
     </figure>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- replace funding note flag icon with green checkmark
- expand funding note into card highlighting grassroots donations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66a4d413c8323993e757b3c95c7c5