### PR TITLE
Refresh contrast page messaging and heading

### DIFF
--- a/contrast.html
+++ b/contrast.html
@@ -280,15 +280,15 @@
   <!-- Section lead -->
   <header class="section-lead">
     <h1>Why I’m the Right Choice</h1>
-    <p class="section-kicker">Clear Claims, Clear Records</p>
-    <p class="section-lead">Compare the records with citations so you can check every claim.</p>
+    <p class="section-kicker">My record is service and results, not talk.</p>
+    <p class="section-lead">I’m not a career politician. I’ll fight for working families, deliver and codify real results for WA-10.</p>
   </header>
 
   <!-- Two-column contrast -->
   <section id="contrast">
     <div class="container contrast-grid">
-      <article class="contrast-card contrast-opponent" aria-labelledby="her-record">
-        <h2 id="her-record">Her Record</h2>
+      <article class="contrast-card contrast-opponent" aria-labelledby="stricklands-record">
+        <h2 id="stricklands-record">Strickland’s Record</h2>
         <p class="booster">Takes PAC money. Votes with corporate interests.</p>
         <ul class="claims">
           <li><i class="fa-solid fa-flag text-danger me-2" aria-hidden="true"></i><strong>AIPAC &amp; corporate PAC money.</strong> Funding tied to outside interests.</li>


### PR DESCRIPTION
## Summary
- Refine contrast page intro to emphasize service, results, and commitment to working families.
- Rename the opponent section header to "Strickland’s Record" and update related anchors.

## Testing
- `npx htmlhint contrast.html` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66e8c70548323b7e2778150c51ac3