### PR TITLE
Refine contrast page header messaging

### DIFF
--- a/contrast.html
+++ b/contrast.html
@@ -249,11 +249,9 @@
 
 <!-- HEADER PILLS -->
 <div class="header-break">
-  <div class="title">Choose independence over influence. Choose results over talk.</div>
+  <div class="title">Choose independence over influence.<br>Choose results over talk.</div>
   <span class="pill">No AIPAC. No corporate PACs.</span>
   <span class="pill">I work for WA‑10, not lobbyists.</span>
-  <span class="pill">Bills that cut costs and expand care.</span>
-  <span class="pill">Radical transparency: votes + calendar.</span>
 </div>
 
 <!-- NAV -->


### PR DESCRIPTION
## Summary
- Split contrast page header into two lines to highlight independence and results
- Remove outdated header pills about bills and transparency

## Testing
- ⚠️ `npx htmlhint contrast.html` *(403 Forbidden - cannot fetch package)*

------
https://chatgpt.com/codex/tasks/task_e_68b66fd57d1c8323ae1ce35afc1628b7