### PR TITLE
Restore arafatforcongress.org domain references

### DIFF
--- a/Bills/Bills.html
+++ b/Bills/Bills.html
@@ -6,17 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>The Evergreen Pact – Step by Step</title>
   <meta name="description" content="Win early. Build momentum. A step-by-step plan that helps now and sets up the hard fights next.">
-  <link rel="canonical" href="https://www.arafatforcongress.org/Bills/Bills.html">
+  <link rel="canonical" href="https://arafatforcongress.org/Bills/Bills.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Arafat for Congress – WA-10">
   <meta property="og:title" content="The Evergreen Pact">
   <meta property="og:description" content="Win early. Build momentum.">
-  <meta property="og:image" content="https://www.arafatforcongress.org/assets/share/og-pact.svg">
-  <meta property="og:url" content="https://www.arafatforcongress.org/Bills/Bills.html">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-pact.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/Bills/Bills.html">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="The Evergreen Pact">
   <meta name="twitter:description" content="Win early. Build momentum.">
-  <meta name="twitter:image" content="https://www.arafatforcongress.org/assets/share/og-pact.svg">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-pact.svg">
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet"/>

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+arafatforcongress.org

--- a/about.html
+++ b/about.html
@@ -14,17 +14,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Meet Adam – Adam Arafat</title>
   <meta name="description" content="Meet Adam Arafat: dad, veteran, and public servant focused on lower costs, real care, and clean government.">
-  <link rel="canonical" href="https://www.arafatforcongress.org/about.html">
+  <link rel="canonical" href="https://arafatforcongress.org/about.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Arafat for Congress – WA-10">
   <meta property="og:title" content="Meet Adam – Adam Arafat">
   <meta property="og:description" content="Dad, veteran, public servant. Trust is built, not bought.">
-  <meta property="og:image" content="https://www.arafatforcongress.org/assets/share/og-home.svg">
-  <meta property="og:url" content="https://www.arafatforcongress.org/about.html">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/about.html">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Meet Adam – Adam Arafat">
   <meta name="twitter:description" content="Dad, veteran, public servant. Trust is built, not bought.">
-  <meta name="twitter:image" content="https://www.arafatforcongress.org/assets/share/og-home.svg">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/assets/share/og-contrast.svg
+++ b/assets/share/og-contrast.svg
@@ -14,5 +14,5 @@
   <text class="title light" x="60" y="200">I work for WA-10, not lobbyists.</text>
   <text class="body muted" x="60" y="280">I refuse corporate PAC money. My votes and budgets are public.</text>
   <text class="body muted" x="60" y="330">Judge me on receipts, not slogans.</text>
-  <text class="tag light" x="60" y="570">See the receipts • www.arafatforcongress.org/contrast.html</text>
+  <text class="tag light" x="60" y="570">See the receipts • arafatforcongress.org/contrast.html</text>
 </svg>

--- a/assets/share/og-issues.svg
+++ b/assets/share/og-issues.svg
@@ -15,5 +15,5 @@
   <text class="list muted" x="60" y="280">1) Lower costs for families</text>
   <text class="list muted" x="60" y="330">2) Healthcare you can use</text>
   <text class="list muted" x="60" y="380">3) End corruption and special interests</text>
-  <text class="tag light" x="60" y="570">Read more • www.arafatforcongress.org/issues.html</text>
+  <text class="tag light" x="60" y="570">Read more • arafatforcongress.org/issues.html</text>
 </svg>

--- a/assets/share/og-pact.svg
+++ b/assets/share/og-pact.svg
@@ -14,5 +14,5 @@
   <text class="title light" x="60" y="200">Win early. Build momentum.</text>
   <text class="body muted" x="60" y="280">A step-by-step plan to pass what helps now</text>
   <text class="body muted" x="60" y="330">and line up the hard fights next.</text>
-  <text class="tag light" x="60" y="570">See the steps • www.arafatforcongress.org/Bills/Bills.html</text>
+  <text class="tag light" x="60" y="570">See the steps • arafatforcongress.org/Bills/Bills.html</text>
 </svg>

--- a/contact.html
+++ b/contact.html
@@ -14,17 +14,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Contact – Adam Arafat for Congress</title>
     <meta name="description" content="Reach the campaign. Join the team building WA-10. Share your story. We read every message.">
-    <link rel="canonical" href="https://www.arafatforcongress.org/contact.html">
+    <link rel="canonical" href="https://arafatforcongress.org/contact.html">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Arafat for Congress – WA-10">
     <meta property="og:title" content="Contact – Adam Arafat for Congress">
     <meta property="og:description" content="Reach the campaign. Join the team building WA-10. We read every message.">
-    <meta property="og:image" content="https://www.arafatforcongress.org/assets/share/og-home.svg">
-    <meta property="og:url" content="https://www.arafatforcongress.org/contact.html">
+    <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
+    <meta property="og:url" content="https://arafatforcongress.org/contact.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact – Adam Arafat for Congress">
     <meta name="twitter:description" content="Reach the campaign. Join the team building WA-10. We read every message.">
-    <meta name="twitter:image" content="https://www.arafatforcongress.org/assets/share/og-home.svg">
+    <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/contrast.html
+++ b/contrast.html
@@ -15,17 +15,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Record and Contrast – Adam Arafat</title>
   <meta name="description" content="I refuse corporate PAC money. My votes and budgets are public. Judge me on receipts.">
-  <link rel="canonical" href="https://www.arafatforcongress.org/contrast.html">
+  <link rel="canonical" href="https://arafatforcongress.org/contrast.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Arafat for Congress – WA-10">
   <meta property="og:title" content="Record and Contrast">
   <meta property="og:description" content="No corporate PAC money. Receipts over rhetoric.">
-  <meta property="og:image" content="https://www.arafatforcongress.org/assets/share/og-contrast.svg">
-  <meta property="og:url" content="https://www.arafatforcongress.org/contrast.html">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-contrast.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/contrast.html">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Record and Contrast">
   <meta name="twitter:description" content="No corporate PAC money. Receipts over rhetoric.">
-  <meta name="twitter:image" content="https://www.arafatforcongress.org/assets/share/og-contrast.svg">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-contrast.svg">
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />

--- a/index.html
+++ b/index.html
@@ -6,17 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Adam Arafat for Congress – WA-10</title>
   <meta name="description" content="Lower costs, healthcare you can use, and clean government. No corporate PAC money.">
-  <link rel="canonical" href="https://www.arafatforcongress.org/">
+  <link rel="canonical" href="https://arafatforcongress.org/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Arafat for Congress – WA-10">
   <meta property="og:title" content="Adam Arafat for Congress – WA-10">
   <meta property="og:description" content="Lower costs, healthcare you can use, and clean government.">
-  <meta property="og:image" content="https://www.arafatforcongress.org/assets/share/og-home.svg">
-  <meta property="og:url" content="https://www.arafatforcongress.org/">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Adam Arafat for Congress – WA-10">
   <meta name="twitter:description" content="Lower costs, healthcare you can use, and clean government.">
-  <meta name="twitter:image" content="https://www.arafatforcongress.org/assets/share/og-home.svg">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-home.svg">
 
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/issues.html
+++ b/issues.html
@@ -6,17 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Where I Stand – Adam Arafat</title>
   <meta name="description" content="The priorities: lower costs, healthcare you can use, end corruption and special interests.">
-  <link rel="canonical" href="https://www.arafatforcongress.org/issues.html">
+  <link rel="canonical" href="https://arafatforcongress.org/issues.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Arafat for Congress – WA-10">
   <meta property="og:title" content="Where I Stand">
   <meta property="og:description" content="Lower costs. Healthcare you can use. End corruption.">
-  <meta property="og:image" content="https://www.arafatforcongress.org/assets/share/og-issues.svg">
-  <meta property="og:url" content="https://www.arafatforcongress.org/issues.html">
+  <meta property="og:image" content="https://arafatforcongress.org/assets/share/og-issues.svg">
+  <meta property="og:url" content="https://arafatforcongress.org/issues.html">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Where I Stand">
   <meta name="twitter:description" content="Lower costs. Healthcare you can use. End corruption.">
-  <meta name="twitter:image" content="https://www.arafatforcongress.org/assets/share/og-issues.svg">
+  <meta name="twitter:image" content="https://arafatforcongress.org/assets/share/og-issues.svg">
   <!-- Bootstrap + Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://www.arafatforcongress.org/sitemap.xml
+Sitemap: https://arafatforcongress.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://www.arafatforcongress.org/</loc></url>
-  <url><loc>https://www.arafatforcongress.org/issues.html</loc></url>
-  <url><loc>https://www.arafatforcongress.org/contrast.html</loc></url>
-  <url><loc>https://www.arafatforcongress.org/Bills/Bills.html</loc></url>
-  <url><loc>https://www.arafatforcongress.org/about.html</loc></url>
-  <url><loc>https://www.arafatforcongress.org/contact.html</loc></url>
+  <url><loc>https://arafatforcongress.org/</loc></url>
+  <url><loc>https://arafatforcongress.org/issues.html</loc></url>
+  <url><loc>https://arafatforcongress.org/contrast.html</loc></url>
+  <url><loc>https://arafatforcongress.org/Bills/Bills.html</loc></url>
+  <url><loc>https://arafatforcongress.org/about.html</loc></url>
+  <url><loc>https://arafatforcongress.org/contact.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- restore the CNAME file so GitHub Pages points to arafatforcongress.org
- update canonical, OpenGraph, and Twitter metadata back to the arafatforcongress.org URLs across primary pages
- refresh share graphics and sitemap/robots entries to match the root domain

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68c848fc91d883239d353fe6e504966f